### PR TITLE
Stop changing the name of the thread hosting the Reactor Runner

### DIFF
--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/messaging/FileUploadNotificationProcessorClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/messaging/FileUploadNotificationProcessorClient.java
@@ -248,10 +248,7 @@ public class FileUploadNotificationProcessorClient
 
         log.debug("Opening FileUploadNotificationProcessorClient");
 
-        this.reactorRunner = new ReactorRunner(
-            this.hostName,
-            "FileUploadNotificationProcessor",
-            this.eventReceivingConnectionHandler);
+        this.reactorRunner = new ReactorRunner(this.eventReceivingConnectionHandler);
 
         final CountDownLatch openLatch = new CountDownLatch(1);
         this.eventReceivingConnectionHandler.setOnConnectionOpenedCallback(openLatch::countDown);

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/messaging/MessageFeedbackProcessorClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/messaging/MessageFeedbackProcessorClient.java
@@ -245,10 +245,7 @@ public class MessageFeedbackProcessorClient
 
         log.debug("Opening MessageFeedbackProcessorClient");
 
-        this.reactorRunner = new ReactorRunner(
-            this.hostName,
-            "MessageFeedbackProcessor",
-            this.eventReceivingConnectionHandler);
+        this.reactorRunner = new ReactorRunner(this.eventReceivingConnectionHandler);
 
         final CountDownLatch openLatch = new CountDownLatch(1);
         this.eventReceivingConnectionHandler.setOnConnectionOpenedCallback(openLatch::countDown);

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/messaging/MessagingClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/messaging/MessagingClient.java
@@ -259,10 +259,7 @@ public final class MessagingClient
 
         log.debug("Opening MessagingClient");
 
-        this.reactorRunner = new ReactorRunner(
-            this.hostName,
-            "MessagingClient",
-            this.cloudToDeviceMessageConnectionHandler);
+        this.reactorRunner = new ReactorRunner(this.cloudToDeviceMessageConnectionHandler);
 
         final CountDownLatch openLatch = new CountDownLatch(1);
         this.cloudToDeviceMessageConnectionHandler.setOnConnectionOpenedCallback(openLatch::countDown);

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/ReactorRunner.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/transport/amqps/ReactorRunner.java
@@ -18,19 +18,12 @@ import java.util.concurrent.TimeUnit;
 @Slf4j
 public class ReactorRunner
 {
-    private final static String THREAD_NAME = "azure-iot-sdk-ReactorRunner";
-    private final String threadName;
     private final Reactor reactor;
     private static final int REACTOR_TIMEOUT = 3141; // reactor timeout in milliseconds
     private static final int MAX_FRAME_SIZE = 4 * 1024;
     private final AmqpConnectionHandler handler;
 
     public ReactorRunner(AmqpConnectionHandler handler) throws IOException
-    {
-        this(null, null, handler);
-    }
-
-    public ReactorRunner(String threadNamePrefix, String threadNamePostfix, AmqpConnectionHandler handler) throws IOException
     {
         ReactorOptions options = new ReactorOptions();
 
@@ -41,26 +34,20 @@ public class ReactorRunner
         options.setMaxFrameSize(MAX_FRAME_SIZE);
 
         this.reactor = Proton.reactor(options, handler);
-        this.threadName = threadNamePrefix + "-" + THREAD_NAME + "-" + threadNamePostfix;
         this.handler = handler;
     }
 
     public void run()
     {
-        if (this.threadName != null)
-        {
-            Thread.currentThread().setName(this.threadName);
-        }
-
         try
         {
-            log.trace("Starting reactor thread {}", this.threadName);
+            log.trace("Starting reactor on thread {}", Thread.currentThread().getName());
             this.reactor.setTimeout(REACTOR_TIMEOUT);
             this.reactor.run();
         }
         catch (HandlerException e)
         {
-            log.debug("Encountered an exception while running reactor on thread {}", threadName, e);
+            log.debug("Encountered an exception while running reactor on thread {}", Thread.currentThread().getName(), e);
         }
         finally
         {
@@ -68,7 +55,7 @@ public class ReactorRunner
             this.reactor.free();
         }
 
-        log.trace("Finished reactor thread {}", this.threadName);
+        log.trace("Finished reactor on thread {}", Thread.currentThread().getName());
     }
 
     public void stop(int timeoutMilliseconds) throws InterruptedException


### PR DESCRIPTION
This PR is more of a question.  It looks like when the iothub service client runs, it renames threads.  This is an example of our application's log file that shows that the threads are being renamed (all to the same value).

![image](https://github.com/Azure/azure-iot-service-sdk-java/assets/1204224/6476e6c1-3709-4490-b007-f0fa20c0313a)

This, from a supportability perspective, is not great.  We have a thread pool that is managing how our application calls out to iotHub, and when the ReactorRunner renames the thread they all show up as the same thread.

This PR is a proposal to stop renaming the threads (as applications are responsible for their naming, etc) and just updated the logging to show which thread is running it  (which, is still not necessary as the log output will already show which thread is generating the log file.

If these changes are not appropriate, may I ask why the thread needs renaming so I understand the thought process here?

Thank you