### PR TITLE
Fix JobsResponseParser null error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -355,3 +355,7 @@ MigrationBackup/
 !iothub-service-client.properties
 !provisioning-device-client.properties
 !provisioning-service-client.properties
+
+target
+.idea
+.flattened-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
         <iot-device-client-version>2.4.0</iot-device-client-version>
-        <iot-service-client-version>2.1.7</iot-service-client-version>
+        <iot-service-client-version>2.1.8</iot-service-client-version>
         <provisioning-device-client-version>2.1.2</provisioning-device-client-version>
         <provisioning-service-client-version>2.0.3</provisioning-service-client-version>
         <security-provider-version>2.0.1</security-provider-version>

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/ScheduledJob.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/ScheduledJob.java
@@ -163,8 +163,8 @@ public class ScheduledJob
                 try
                 {
                     this.outcomeResult = new DirectMethodResponse(
-                        jobsResponseParser.getCloudToDeviceMethod().getStatus(),
-                        new GsonBuilder().create().toJsonTree(jobsResponseParser.getCloudToDeviceMethod().getPayload()));
+                        jobsResponseParser.getMethodResponse().getStatus(),
+                        new GsonBuilder().create().toJsonTree(jobsResponseParser.getMethodResponse().getPayload()));
                 }
                 catch (IllegalArgumentException e)
                 {

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/serializers/JobsResponseParser.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/serializers/JobsResponseParser.java
@@ -147,6 +147,7 @@ public class JobsResponseParser
 
     // The contents of outcome for job query if any.
     private static final String DEVICE_METHOD_RESPONSE_TAG = "deviceMethodResponse";
+    @Getter
     private MethodParser methodResponse;
 
     // Required if type is updateTwin.


### PR DESCRIPTION
Obtain the job outcome from method response when the job type is `scheduleDeviceMethod`.

Fixes https://github.com/Azure/azure-iot-service-sdk-java/issues/30