### PR TITLE
Bump commons-io 2.7 -> 2.14.0 to address CVE-2021-29425

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.7</version> <!--samples only-->
+                <version>2.14.0</version> <!--samples only-->
             </dependency>
             <dependency>
                 <groupId>com.azure</groupId>


### PR DESCRIPTION
Samples-only dependency. No source changes required.