### PR TITLE
Bump Netty 4.1.100 -> 4.1.130 and remove UDT references

### DIFF
--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/proxy/impl/DefaultHttpProxyServer.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/proxy/impl/DefaultHttpProxyServer.java
@@ -7,7 +7,7 @@ import io.netty.channel.group.ChannelGroup;
 import io.netty.channel.group.ChannelGroupFuture;
 import io.netty.channel.group.DefaultChannelGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
-import io.netty.channel.udt.nio.NioUdtProvider;
+
 import io.netty.handler.traffic.GlobalTrafficShapingHandler;
 import io.netty.util.concurrent.GlobalEventExecutor;
 import org.slf4j.Logger;
@@ -510,11 +510,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
                 });
                 break;
             case UDT:
-                LOG.info("Proxy listening with UDT transport");
-                serverBootstrap.channelFactory(NioUdtProvider.BYTE_ACCEPTOR)
-                        .option(ChannelOption.SO_BACKLOG, 10)
-                        .option(ChannelOption.SO_REUSEADDR, true);
-                break;
+                throw new UnknownTransportProtocolException(transportProtocol);
             default:
                 throw new UnknownTransportProtocolException(transportProtocol);
         }

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/proxy/impl/ProxyToServerConnection.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/proxy/impl/ProxyToServerConnection.java
@@ -7,7 +7,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.*;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.socket.nio.NioSocketChannel;
-import io.netty.channel.udt.nio.NioUdtProvider;
+
 import io.netty.handler.codec.http.*;
 import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.handler.traffic.GlobalTrafficShapingHandler;
@@ -583,10 +583,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse>
                 });
                 break;
             case UDT:
-                log.trace("Connecting to server with UDT");
-                cb.channelFactory(NioUdtProvider.BYTE_CONNECTOR)
-                        .option(ChannelOption.SO_REUSEADDR, true);
-                break;
+                throw new UnknownTransportProtocolException(transportProtocol);
             default:
                 throw new UnknownTransportProtocolException(transportProtocol);
             }

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/proxy/impl/ProxyUtils.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/proxy/impl/ProxyUtils.java
@@ -5,7 +5,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.channel.udt.nio.NioUdtProvider;
+
 import io.netty.handler.codec.http.*;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
@@ -555,11 +555,7 @@ public class ProxyUtils {
      * @return true if UDT is available
      */
     public static boolean isUdtAvailable() {
-        try {
-            return NioUdtProvider.BYTE_PROVIDER != null;
-        } catch (NoClassDefFoundError e) {
-            return false;
-        }
+        return false;
     }
 
     /**

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/proxy/impl/ServerGroup.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/helpers/proxy/impl/ServerGroup.java
@@ -1,7 +1,7 @@
 package tests.integration.com.microsoft.azure.sdk.iot.helpers.proxy.impl;
 
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.udt.nio.NioUdtProvider;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import tests.integration.com.microsoft.azure.sdk.iot.helpers.proxy.HttpProxyServer;
@@ -80,13 +80,8 @@ public class ServerGroup {
     static {
         TRANSPORT_PROTOCOL_SELECTOR_PROVIDERS.put(TransportProtocol.TCP, SelectorProvider.provider());
 
-        // allow the proxy to operate without UDT support. this allows clients that do not use UDT to exclude the barchart
-        // dependency completely.
-        if (ProxyUtils.isUdtAvailable()) {
-            TRANSPORT_PROTOCOL_SELECTOR_PROVIDERS.put(TransportProtocol.UDT, NioUdtProvider.BYTE_PROVIDER);
-        } else {
-            log.trace("UDT provider not found on classpath. UDT transport will not be available.");
-        }
+        // UDT transport is no longer available (netty-transport-udt was removed in Netty 4.1.87+)
+        log.trace("UDT provider is no longer available. UDT transport will not be available.");
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -107,27 +107,27 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-all</artifactId>
-                <version>4.1.100.Final</version> <!--e2e tests and samples only-->
+                <version>4.1.130.Final</version> <!--e2e tests and samples only-->
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-handler</artifactId>
-                <version>4.1.100.Final</version> <!--e2e tests and samples only-->
+                <version>4.1.130.Final</version> <!--e2e tests and samples only-->
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec</artifactId>
-                <version>4.1.100.Final</version> <!--e2e tests and samples only-->
+                <version>4.1.130.Final</version> <!--e2e tests and samples only-->
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http</artifactId>
-                <version>4.1.100.Final</version> <!--e2e tests and samples only-->
+                <version>4.1.130.Final</version> <!--e2e tests and samples only-->
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http2</artifactId>
-                <version>4.1.100.Final</version> <!--e2e tests and samples only-->
+                <version>4.1.130.Final</version> <!--e2e tests and samples only-->
             </dependency>
             <dependency>
                 <groupId>commons-cli</groupId>


### PR DESCRIPTION
- Update netty-all, netty-handler, netty-codec, netty-codec-http, netty-codec-http2 in dependencyManagement
- Remove NioUdtProvider/UDT usages from E2E proxy helpers (UDT was removed from Netty in 4.1.87+)

Affects E2E tests and samples only.