### PR TITLE
Add negative-timeout validation to *ClientOptions builders

### DIFF
--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/configurations/ConfigurationsClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/configurations/ConfigurationsClientOptions.java
@@ -41,4 +41,23 @@ public class ConfigurationsClientOptions
     @Getter
     @Builder.Default
     private final int httpConnectTimeoutSeconds = DEFAULT_HTTP_CONNECT_TIMEOUT_SECONDS;
+
+    // Custom builder to add validation for timeout values
+    public static class ConfigurationsClientOptionsBuilder
+    {
+        public ConfigurationsClientOptions build()
+        {
+            if (httpReadTimeoutSeconds$set && httpReadTimeoutSeconds$value < 0)
+            {
+                throw new IllegalArgumentException("httpReadTimeoutSeconds must be a non-negative value");
+            }
+            if (httpConnectTimeoutSeconds$set && httpConnectTimeoutSeconds$value < 0)
+            {
+                throw new IllegalArgumentException("httpConnectTimeoutSeconds must be a non-negative value");
+            }
+            return new ConfigurationsClientOptions(proxyOptions,
+                httpReadTimeoutSeconds$set ? httpReadTimeoutSeconds$value : DEFAULT_HTTP_READ_TIMEOUT_SECONDS,
+                httpConnectTimeoutSeconds$set ? httpConnectTimeoutSeconds$value : DEFAULT_HTTP_CONNECT_TIMEOUT_SECONDS);
+        }
+    }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinClientOptions.java
@@ -42,4 +42,23 @@ public class DigitalTwinClientOptions
     @Getter
     @Builder.Default
     private final int httpConnectTimeoutSeconds = DEFAULT_HTTP_CONNECT_TIMEOUT_SECONDS;
+
+    // Custom builder to add validation for timeout values
+    public static class DigitalTwinClientOptionsBuilder
+    {
+        public DigitalTwinClientOptions build()
+        {
+            if (httpReadTimeoutSeconds$set && httpReadTimeoutSeconds$value < 0)
+            {
+                throw new IllegalArgumentException("httpReadTimeoutSeconds must be a non-negative value");
+            }
+            if (httpConnectTimeoutSeconds$set && httpConnectTimeoutSeconds$value < 0)
+            {
+                throw new IllegalArgumentException("httpConnectTimeoutSeconds must be a non-negative value");
+            }
+            return new DigitalTwinClientOptions(proxyOptions,
+                httpReadTimeoutSeconds$set ? httpReadTimeoutSeconds$value : DEFAULT_HTTP_READ_TIMEOUT_SECONDS,
+                httpConnectTimeoutSeconds$set ? httpConnectTimeoutSeconds$value : DEFAULT_HTTP_CONNECT_TIMEOUT_SECONDS);
+        }
+    }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/ScheduledJobsClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/jobs/ScheduledJobsClientOptions.java
@@ -41,4 +41,23 @@ public final class ScheduledJobsClientOptions
     @Getter
     @Builder.Default
     private final int httpConnectTimeoutSeconds = DEFAULT_HTTP_CONNECT_TIMEOUT_SECONDS;
+
+    // Custom builder to add validation for timeout values
+    public static class ScheduledJobsClientOptionsBuilder
+    {
+        public ScheduledJobsClientOptions build()
+        {
+            if (httpReadTimeoutSeconds$set && httpReadTimeoutSeconds$value < 0)
+            {
+                throw new IllegalArgumentException("httpReadTimeoutSeconds must be a non-negative value");
+            }
+            if (httpConnectTimeoutSeconds$set && httpConnectTimeoutSeconds$value < 0)
+            {
+                throw new IllegalArgumentException("httpConnectTimeoutSeconds must be a non-negative value");
+            }
+            return new ScheduledJobsClientOptions(proxyOptions,
+                httpReadTimeoutSeconds$set ? httpReadTimeoutSeconds$value : DEFAULT_HTTP_READ_TIMEOUT_SECONDS,
+                httpConnectTimeoutSeconds$set ? httpConnectTimeoutSeconds$value : DEFAULT_HTTP_CONNECT_TIMEOUT_SECONDS);
+        }
+    }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/methods/DirectMethodsClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/methods/DirectMethodsClientOptions.java
@@ -38,4 +38,23 @@ public final class DirectMethodsClientOptions
     @Getter
     @Builder.Default
     private final int httpConnectTimeoutSeconds = DEFAULT_HTTP_CONNECT_TIMEOUT_SECONDS;
+
+    // Custom builder to add validation for timeout values
+    public static class DirectMethodsClientOptionsBuilder
+    {
+        public DirectMethodsClientOptions build()
+        {
+            if (httpReadTimeoutSeconds$set && httpReadTimeoutSeconds$value < 0)
+            {
+                throw new IllegalArgumentException("httpReadTimeoutSeconds must be a non-negative value");
+            }
+            if (httpConnectTimeoutSeconds$set && httpConnectTimeoutSeconds$value < 0)
+            {
+                throw new IllegalArgumentException("httpConnectTimeoutSeconds must be a non-negative value");
+            }
+            return new DirectMethodsClientOptions(proxyOptions,
+                httpReadTimeoutSeconds$set ? httpReadTimeoutSeconds$value : DEFAULT_HTTP_READ_TIMEOUT_SECONDS,
+                httpConnectTimeoutSeconds$set ? httpConnectTimeoutSeconds$value : DEFAULT_HTTP_CONNECT_TIMEOUT_SECONDS);
+        }
+    }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/query/QueryClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/query/QueryClientOptions.java
@@ -41,4 +41,23 @@ public final class QueryClientOptions
     @Getter
     @Builder.Default
     private final int httpConnectTimeoutSeconds = DEFAULT_HTTP_CONNECT_TIMEOUT_SECONDS;
+
+    // Custom builder to add validation for timeout values
+    public static class QueryClientOptionsBuilder
+    {
+        public QueryClientOptions build()
+        {
+            if (httpReadTimeoutSeconds$set && httpReadTimeoutSeconds$value < 0)
+            {
+                throw new IllegalArgumentException("httpReadTimeoutSeconds must be a non-negative value");
+            }
+            if (httpConnectTimeoutSeconds$set && httpConnectTimeoutSeconds$value < 0)
+            {
+                throw new IllegalArgumentException("httpConnectTimeoutSeconds must be a non-negative value");
+            }
+            return new QueryClientOptions(proxyOptions,
+                httpReadTimeoutSeconds$set ? httpReadTimeoutSeconds$value : DEFAULT_HTTP_READ_TIMEOUT_SECONDS,
+                httpConnectTimeoutSeconds$set ? httpConnectTimeoutSeconds$value : DEFAULT_HTTP_CONNECT_TIMEOUT_SECONDS);
+        }
+    }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/registry/RegistryClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/registry/RegistryClientOptions.java
@@ -38,4 +38,23 @@ public final class RegistryClientOptions
     @Getter
     @Builder.Default
     private final int httpConnectTimeoutSeconds = DEFAULT_HTTP_CONNECT_TIMEOUT_SECONDS;
+
+    // Custom builder to add validation for timeout values
+    public static class RegistryClientOptionsBuilder
+    {
+        public RegistryClientOptions build()
+        {
+            if (httpReadTimeoutSeconds$set && httpReadTimeoutSeconds$value < 0)
+            {
+                throw new IllegalArgumentException("httpReadTimeoutSeconds must be a non-negative value");
+            }
+            if (httpConnectTimeoutSeconds$set && httpConnectTimeoutSeconds$value < 0)
+            {
+                throw new IllegalArgumentException("httpConnectTimeoutSeconds must be a non-negative value");
+            }
+            return new RegistryClientOptions(proxyOptions,
+                httpReadTimeoutSeconds$set ? httpReadTimeoutSeconds$value : DEFAULT_HTTP_READ_TIMEOUT_SECONDS,
+                httpConnectTimeoutSeconds$set ? httpConnectTimeoutSeconds$value : DEFAULT_HTTP_CONNECT_TIMEOUT_SECONDS);
+        }
+    }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/TwinClientOptions.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/twin/TwinClientOptions.java
@@ -38,4 +38,23 @@ public final class TwinClientOptions
     @Getter
     @Builder.Default
     private final int httpConnectTimeoutSeconds = DEFAULT_HTTP_CONNECT_TIMEOUT_SECONDS;
+
+    // Custom builder to add validation for timeout values
+    public static class TwinClientOptionsBuilder
+    {
+        public TwinClientOptions build()
+        {
+            if (httpReadTimeoutSeconds$set && httpReadTimeoutSeconds$value < 0)
+            {
+                throw new IllegalArgumentException("httpReadTimeoutSeconds must be a non-negative value");
+            }
+            if (httpConnectTimeoutSeconds$set && httpConnectTimeoutSeconds$value < 0)
+            {
+                throw new IllegalArgumentException("httpConnectTimeoutSeconds must be a non-negative value");
+            }
+            return new TwinClientOptions(proxyOptions,
+                httpReadTimeoutSeconds$set ? httpReadTimeoutSeconds$value : DEFAULT_HTTP_READ_TIMEOUT_SECONDS,
+                httpConnectTimeoutSeconds$set ? httpConnectTimeoutSeconds$value : DEFAULT_HTTP_CONNECT_TIMEOUT_SECONDS);
+        }
+    }
 }


### PR DESCRIPTION
Throws IllegalArgumentException when httpReadTimeoutSeconds or httpConnectTimeoutSeconds is set to a negative value. Applied to: RegistryClientOptions, TwinClientOptions, DirectMethodsClientOptions, ScheduledJobsClientOptions, QueryClientOptions, ConfigurationsClientOptions, DigitalTwinClientOptions.