### PR TITLE
Migrate from com.microsoft.rest:client-runtime to com.azure:azure-core

### DIFF
--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/digitaltwin/DigitalTwinClientComponentTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/digitaltwin/DigitalTwinClientComponentTests.java
@@ -14,7 +14,7 @@ import com.microsoft.azure.sdk.iot.service.digitaltwin.customized.DigitalTwinGet
 import com.microsoft.azure.sdk.iot.service.digitaltwin.models.*;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.serialization.BasicDigitalTwin;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
-import com.microsoft.rest.ServiceResponseWithHeaders;
+import com.microsoft.azure.sdk.iot.service.digitaltwin.models.ServiceResponseWithHeaders;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.*;
 import org.junit.rules.Timeout;

--- a/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/digitaltwin/DigitalTwinClientTests.java
+++ b/iot-e2e-tests/common/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/digitaltwin/DigitalTwinClientTests.java
@@ -19,8 +19,8 @@ import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import com.microsoft.azure.sdk.iot.service.registry.Device;
 import com.microsoft.azure.sdk.iot.service.registry.RegistryClient;
 import com.microsoft.azure.sdk.iot.service.registry.RegistryClientOptions;
-import com.microsoft.rest.RestException;
-import com.microsoft.rest.ServiceResponseWithHeaders;
+import com.azure.core.exception.HttpResponseException;
+import com.microsoft.azure.sdk.iot.service.digitaltwin.models.ServiceResponseWithHeaders;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.*;
 import org.junit.rules.Timeout;
@@ -253,9 +253,9 @@ public class DigitalTwinClientTests extends IntegrationTest
             digitalTwinClient.getDigitalTwin(deviceId, BasicDigitalTwin.class);
             fail("Expected get digital twin call to throw unauthorized exception since an expired SAS token was used, but no exception was thrown");
         }
-        catch (RestException e)
+        catch (HttpResponseException e)
         {
-            if (e.response().code() == 401)
+            if (e.getResponse().getStatusCode() == 401)
             {
                 log.debug("IotHubUnauthorizedException was thrown as expected, continuing test");
             }

--- a/iot-e2e-tests/iot-e2e-jvm-tests/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/TokenCredentialTests.java
+++ b/iot-e2e-tests/iot-e2e-jvm-tests/src/test/java/tests/integration/com/microsoft/azure/sdk/iot/TokenCredentialTests.java
@@ -25,7 +25,7 @@ import com.microsoft.azure.sdk.iot.service.digitaltwin.serialization.BasicDigita
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import com.microsoft.azure.sdk.iot.service.query.QueryClient;
 import com.microsoft.azure.sdk.iot.service.query.TwinQueryResponse;
-import com.microsoft.rest.ServiceResponseWithHeaders;
+import com.microsoft.azure.sdk.iot.service.digitaltwin.models.ServiceResponseWithHeaders;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Assume;
 import org.junit.Ignore;

--- a/pom.xml
+++ b/pom.xml
@@ -55,9 +55,9 @@
                 <version>1.7.32</version>
             </dependency>
             <dependency>
-                <groupId>com.microsoft.rest</groupId>
-                <artifactId>client-runtime</artifactId>
-                <version>1.7.14</version>
+                <groupId>com.azure</groupId>
+                <artifactId>azure-core-http-netty</artifactId>
+                <version>1.16.3</version>
             </dependency>
             <dependency>
                 <groupId>com.google.code.findbugs</groupId>
@@ -67,7 +67,7 @@
             <dependency>
                 <groupId>com.azure</groupId>
                 <artifactId>azure-core</artifactId>
-                <version>1.12.0</version>
+                <version>1.57.1</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
@@ -159,18 +159,12 @@
                 <artifactId>log4j-slf4j-impl</artifactId>
                 <version>2.17.1</version>  <!--e2e tests and samples only-->
             </dependency>
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>32.0.0-jre</version> <!-- Nested dependency from ms client runtime. Overriding the version to use newer version-->
-            </dependency>
+
         </dependencies>
     </dependencyManagement>
     <properties>
-        <iot-device-client-artifact-id>iot-device-client</iot-device-client-artifact-id>
         <iot-service-client-artifact-id>iot-service-client</iot-service-client-artifact-id>
-        <provisioning-device-client-artifact-id>provisioning-device-client</provisioning-device-client-artifact-id>
-        <provisioning-service-client-artifact-id>provisioning-service-client</provisioning-service-client-artifact-id>
+        <iot-device-client-artifact-id>iot-device-client</iot-device-client-artifact-id>
         <security-provider-artifact-id>security-provider</security-provider-artifact-id>
         <tpm-provider-emulator-artifact-id>tpm-provider-emulator</tpm-provider-emulator-artifact-id>
         <tpm-provider-artifact-id>tpm-provider</tpm-provider-artifact-id>
@@ -178,10 +172,8 @@
         <dice-provider-artifact-id>dice-provider</dice-provider-artifact-id>
         <x509-provider-artifact-id>x509-provider</x509-provider-artifact-id>
 
-        <iot-device-client-version>2.4.0</iot-device-client-version>
-        <iot-service-client-version>2.1.10</iot-service-client-version>
-        <provisioning-device-client-version>2.1.2</provisioning-device-client-version>
-        <provisioning-service-client-version>2.0.3</provisioning-service-client-version>
+        <iot-service-client-version>2.2.0</iot-service-client-version>
+        <iot-device-client-version>2.5.0</iot-device-client-version>
         <security-provider-version>2.0.1</security-provider-version>
         <tpm-provider-emulator-version>2.0.1</tpm-provider-emulator-version>
         <tpm-provider-version>2.0.1</tpm-provider-version>

--- a/service/iot-service-client/pom.xml
+++ b/service/iot-service-client/pom.xml
@@ -40,8 +40,13 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>com.microsoft.rest</groupId>
-            <artifactId>client-runtime</artifactId>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-core-http-netty</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.reactivex</groupId>
+            <artifactId>rxjava</artifactId>
+            <version>1.3.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.qpid</groupId>
@@ -97,23 +102,10 @@
             <scope>test</scope>
         </dependency>
 
-        <!--Nested dependencies that need to be explicitly declared for the versions defined in the main
-        pom.xml file's dependency management section to be enforced. Otherwise, the versions of these nested dependencies
-        will be chosen based by the dependency they are nested under. For instance, we are using the library
-        com.microsoft.rest:client-runtime which has a dependency on guava version 20.0 which has vulnerabilities. In our
-        dependency management section in the main pom.xml file we override this version to be 31.1-jre. Even with that, though,
-        we still need to declare the dependency here in order to enforce this version override.-->
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
+        <!--jackson-databind is still needed as a direct dependency-->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-joda</artifactId>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinAsyncClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinAsyncClient.java
@@ -5,11 +5,12 @@ package com.microsoft.azure.sdk.iot.service.digitaltwin;
 
 import com.azure.core.credential.AzureSasCredential;
 import com.azure.core.credential.TokenCredential;
+import com.azure.core.http.HttpPipeline;
+import com.azure.core.http.HttpPipelineBuilder;
+import com.azure.core.http.policy.HttpPipelinePolicy;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.microsoft.azure.sdk.iot.service.ProxyOptions;
-import com.microsoft.azure.sdk.iot.service.auth.TokenCredentialCache;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.authentication.BearerTokenProvider;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.authentication.SasTokenProvider;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.authentication.ServiceClientBearerTokenCredentialProvider;
@@ -26,23 +27,18 @@ import com.microsoft.azure.sdk.iot.service.digitaltwin.models.DigitalTwinCommand
 import com.microsoft.azure.sdk.iot.service.digitaltwin.models.DigitalTwinInvokeCommandHeaders;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.models.DigitalTwinInvokeCommandRequestOptions;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.models.DigitalTwinUpdateRequestOptions;
+import com.microsoft.azure.sdk.iot.service.digitaltwin.models.ServiceResponseWithHeaders;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.serialization.DeserializationHelpers;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.serialization.DigitalTwinStringSerializer;
+import com.microsoft.azure.sdk.iot.service.auth.TokenCredentialCache;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
 import com.microsoft.azure.sdk.iot.service.transport.TransportUtils;
-import com.microsoft.rest.RestClient;
-import com.microsoft.rest.ServiceResponse;
-import com.microsoft.rest.ServiceResponseBuilder;
-import com.microsoft.rest.ServiceResponseWithHeaders;
-import com.microsoft.rest.serializer.JacksonAdapter;
 import lombok.extern.slf4j.Slf4j;
 import rx.Observable;
 import rx.schedulers.Schedulers;
 
-import java.net.Proxy;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 
 import static com.microsoft.azure.sdk.iot.service.digitaltwin.helpers.Tools.*;
 
@@ -77,31 +73,15 @@ public class DigitalTwinAsyncClient {
         ServiceConnectionString serviceConnectionString = ServiceConnectionStringParser.parseConnectionString(connectionString);
         SasTokenProvider sasTokenProvider = serviceConnectionString.createSasTokenProvider();
         String httpsEndpoint = serviceConnectionString.getHttpsEndpoint();
-        final SimpleModule stringModule = new SimpleModule("String Serializer");
-        stringModule.addSerializer(new DigitalTwinStringSerializer(String.class, objectMapper));
 
-        JacksonAdapter adapter = new JacksonAdapter();
-        adapter.serializer().registerModule(stringModule);
-
-        ProxyOptions proxyOptions = options.getProxyOptions();
-        Proxy proxy = null;
-        if (proxyOptions != null)
-        {
-            proxy = proxyOptions.getProxy();
-        }
-
-        RestClient simpleRestClient = new RestClient.Builder()
-            .withConnectionTimeout(options.getHttpConnectTimeoutSeconds(), TimeUnit.SECONDS)
-            .withReadTimeout(options.getHttpReadTimeoutSeconds(), TimeUnit.SECONDS)
-            .withProxy(proxy) // assigning a null proxy here just means no proxy will be used
-            .withBaseUrl(httpsEndpoint)
-            .withCredentials(new ServiceClientCredentialsProvider(sasTokenProvider))
-            .withResponseBuilderFactory(new ServiceResponseBuilder.Factory())
-            .withSerializerAdapter(adapter)
+        HttpPipelinePolicy authPolicy = new ServiceClientCredentialsProvider(sasTokenProvider);
+        HttpPipeline pipeline = new HttpPipelineBuilder()
+            .policies(authPolicy)
             .build();
 
-        IotHubGatewayServiceAPIsImpl protocolLayerClient = new IotHubGatewayServiceAPIsImpl(simpleRestClient);
-        _protocolLayer = new DigitalTwinsImpl(simpleRestClient.retrofit(), protocolLayerClient);
+        ObjectMapper mapper = createObjectMapper();
+        IotHubGatewayServiceAPIsImpl protocolLayerClient = new IotHubGatewayServiceAPIsImpl(pipeline, mapper, httpsEndpoint);
+        _protocolLayer = new DigitalTwinsImpl(protocolLayerClient);
         commonConstructorSetup();
     }
 
@@ -126,36 +106,19 @@ public class DigitalTwinAsyncClient {
      */
     public DigitalTwinAsyncClient(String hostName, TokenCredential credential, DigitalTwinClientOptions options) {
         Objects.requireNonNull(options);
-        final SimpleModule stringModule = new SimpleModule("String Serializer");
-        stringModule.addSerializer(new DigitalTwinStringSerializer(String.class, objectMapper));
         TokenCredentialCache tokenCredentialCache = new TokenCredentialCache(credential);
         BearerTokenProvider bearerTokenProvider = () -> tokenCredentialCache.getTokenString();
 
-        JacksonAdapter adapter = new JacksonAdapter();
-        adapter.serializer().registerModule(stringModule);
-
-        ProxyOptions proxyOptions = options.getProxyOptions();
-        Proxy proxy = null;
-        if (proxyOptions != null)
-        {
-            proxy = proxyOptions.getProxy();
-        }
-
-        RestClient simpleRestClient = new RestClient.Builder()
-            .withBaseUrl(HTTPS_SCHEME + hostName) //hostname is only "my-iot-hub.azure-devices.net" so we need to add "https://"
-            .withConnectionTimeout(options.getHttpConnectTimeoutSeconds(), TimeUnit.SECONDS)
-            .withReadTimeout(options.getHttpReadTimeoutSeconds(), TimeUnit.SECONDS)
-            .withProxy(proxy) // assigning a null proxy here just means no proxy will be used
-            .withCredentials(new ServiceClientBearerTokenCredentialProvider(bearerTokenProvider))
-            .withResponseBuilderFactory(new ServiceResponseBuilder.Factory())
-            .withSerializerAdapter(adapter)
+        HttpPipelinePolicy authPolicy = new ServiceClientBearerTokenCredentialProvider(bearerTokenProvider);
+        HttpPipeline pipeline = new HttpPipelineBuilder()
+            .policies(authPolicy)
             .build();
 
-        IotHubGatewayServiceAPIsImpl protocolLayerClient = new IotHubGatewayServiceAPIsImpl(simpleRestClient);
-        _protocolLayer = new DigitalTwinsImpl(simpleRestClient.retrofit(), protocolLayerClient);
+        ObjectMapper mapper = createObjectMapper();
+        IotHubGatewayServiceAPIsImpl protocolLayerClient = new IotHubGatewayServiceAPIsImpl(pipeline, mapper, HTTPS_SCHEME + hostName);
+        _protocolLayer = new DigitalTwinsImpl(protocolLayerClient);
         commonConstructorSetup();
     }
-
 
     /**
      * Creates an implementation instance of {@link DigitalTwins} that is used to invoke the Digital Twin features
@@ -176,32 +139,16 @@ public class DigitalTwinAsyncClient {
      */
     public DigitalTwinAsyncClient(String hostName, AzureSasCredential azureSasCredential, DigitalTwinClientOptions options) {
         Objects.requireNonNull(options);
-        final SimpleModule stringModule = new SimpleModule("String Serializer");
-        stringModule.addSerializer(new DigitalTwinStringSerializer(String.class, objectMapper));
         SasTokenProvider sasTokenProvider = azureSasCredential::getSignature;
 
-        JacksonAdapter adapter = new JacksonAdapter();
-        adapter.serializer().registerModule(stringModule);
-
-        ProxyOptions proxyOptions = options.getProxyOptions();
-        Proxy proxy = null;
-        if (proxyOptions != null)
-        {
-            proxy = proxyOptions.getProxy();
-        }
-
-        RestClient simpleRestClient = new RestClient.Builder()
-            .withBaseUrl(HTTPS_SCHEME + hostName) //hostname is only "my-iot-hub.azure-devices.net" so we need to add "https://"
-            .withConnectionTimeout(options.getHttpConnectTimeoutSeconds(), TimeUnit.SECONDS)
-            .withReadTimeout(options.getHttpReadTimeoutSeconds(), TimeUnit.SECONDS)
-            .withProxy(proxy) // assigning a null proxy here just means no proxy will be used
-            .withCredentials(new ServiceClientCredentialsProvider(sasTokenProvider))
-            .withResponseBuilderFactory(new ServiceResponseBuilder.Factory())
-            .withSerializerAdapter(adapter)
+        HttpPipelinePolicy authPolicy = new ServiceClientCredentialsProvider(sasTokenProvider);
+        HttpPipeline pipeline = new HttpPipelineBuilder()
+            .policies(authPolicy)
             .build();
 
-        IotHubGatewayServiceAPIsImpl protocolLayerClient = new IotHubGatewayServiceAPIsImpl(simpleRestClient);
-        _protocolLayer = new DigitalTwinsImpl(simpleRestClient.retrofit(), protocolLayerClient);
+        ObjectMapper mapper = createObjectMapper();
+        IotHubGatewayServiceAPIsImpl protocolLayerClient = new IotHubGatewayServiceAPIsImpl(pipeline, mapper, HTTPS_SCHEME + hostName);
+        _protocolLayer = new DigitalTwinsImpl(protocolLayerClient);
         commonConstructorSetup();
     }
 
@@ -213,6 +160,14 @@ public class DigitalTwinAsyncClient {
      */
     public static DigitalTwinAsyncClient createFromConnectionString(String connectionString) {
         return new DigitalTwinAsyncClient(connectionString);
+    }
+
+    private static ObjectMapper createObjectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        final SimpleModule stringModule = new SimpleModule("String Serializer");
+        stringModule.addSerializer(new DigitalTwinStringSerializer(String.class, objectMapper));
+        mapper.registerModule(stringModule);
+        return mapper;
     }
 
     private static void commonConstructorSetup() {
@@ -229,7 +184,7 @@ public class DigitalTwinAsyncClient {
     public <T> Observable<T> getDigitalTwin(String digitalTwinId, Class<T> clazz)
     {
         return getDigitalTwinWithResponse(digitalTwinId, clazz)
-                .map(ServiceResponse::body);
+                .map(ServiceResponseWithHeaders::body);
     }
 
     /**
@@ -251,7 +206,7 @@ public class DigitalTwinAsyncClient {
                 .flatMap(response -> {
                     try {
                         T genericResponse = DeserializationHelpers.castObject(objectMapper, response.body(), clazz);
-                        return Observable.just(new ServiceResponseWithHeaders<>(genericResponse, response.headers(), response.response()));
+                        return Observable.just(new ServiceResponseWithHeaders<>(genericResponse, response.headers(), response.statusCode()));
                     } catch (JsonProcessingException e) {
                         return Observable.error(new IotHubException("Failed to parse the resonse"));
                     }
@@ -269,7 +224,7 @@ public class DigitalTwinAsyncClient {
     public Observable<Void> updateDigitalTwin(String digitalTwinId, List<Object> digitalTwinUpdateOperations)
     {
         return updateDigitalTwinWithResponse(digitalTwinId, digitalTwinUpdateOperations, null)
-                .map(ServiceResponse::body);
+                .map(ServiceResponseWithHeaders::body);
     }
 
     /**
@@ -307,7 +262,7 @@ public class DigitalTwinAsyncClient {
     public Observable<DigitalTwinCommandResponse> invokeCommand(String digitalTwinId, String commandName)
     {
         return invokeCommandWithResponse(digitalTwinId, commandName, null, null)
-                .map(ServiceResponse::body);
+                .map(ServiceResponseWithHeaders::body);
     }
 
     /**
@@ -319,9 +274,8 @@ public class DigitalTwinAsyncClient {
      */
     public Observable<DigitalTwinCommandResponse> invokeCommand(String digitalTwinId, String commandName, String payload)
     {
-        // Retrofit does not work well with null in body
         return invokeCommandWithResponse(digitalTwinId, commandName, payload, null)
-                .map(ServiceResponse::body);
+                .map(ServiceResponseWithHeaders::body);
     }
 
     /**
@@ -339,7 +293,6 @@ public class DigitalTwinAsyncClient {
             options = new DigitalTwinInvokeCommandRequestOptions();
         }
 
-        // Retrofit does not work well with null in body
         if (payload == null)
         {
             payload = "";
@@ -360,7 +313,7 @@ public class DigitalTwinAsyncClient {
     public Observable<DigitalTwinCommandResponse> invokeComponentCommand(String digitalTwinId, String componentName, String commandName)
     {
         return invokeComponentCommandWithResponse(digitalTwinId, componentName, commandName, null, null)
-                .map(ServiceResponse::body);
+                .map(ServiceResponseWithHeaders::body);
     }
 
     /**
@@ -374,7 +327,7 @@ public class DigitalTwinAsyncClient {
     public Observable<DigitalTwinCommandResponse> invokeComponentCommand(String digitalTwinId, String componentName, String commandName, String payload)
     {
         return invokeComponentCommandWithResponse(digitalTwinId, componentName, commandName, payload, null)
-                .map(ServiceResponse::body);
+                .map(ServiceResponseWithHeaders::body);
     }
 
     /**
@@ -393,7 +346,6 @@ public class DigitalTwinAsyncClient {
             options = new DigitalTwinInvokeCommandRequestOptions();
         }
 
-        // Retrofit does not work well with null in body
         if (payload == null)
         {
             payload = "";

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinClient.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/DigitalTwinClient.java
@@ -13,7 +13,7 @@ import com.microsoft.azure.sdk.iot.service.digitaltwin.models.DigitalTwinCommand
 import com.microsoft.azure.sdk.iot.service.digitaltwin.models.DigitalTwinInvokeCommandHeaders;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.models.DigitalTwinInvokeCommandRequestOptions;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.models.DigitalTwinUpdateRequestOptions;
-import com.microsoft.rest.ServiceResponseWithHeaders;
+import com.microsoft.azure.sdk.iot.service.digitaltwin.models.ServiceResponseWithHeaders;
 
 import java.util.List;
 

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/authentication/ServiceClientBearerTokenCredentialProvider.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/authentication/ServiceClientBearerTokenCredentialProvider.java
@@ -3,18 +3,19 @@
 
 package com.microsoft.azure.sdk.iot.service.digitaltwin.authentication;
 
-import com.microsoft.rest.credentials.ServiceClientCredentials;
+import com.azure.core.http.HttpPipelineCallContext;
+import com.azure.core.http.HttpPipelineNextPolicy;
+import com.azure.core.http.HttpResponse;
+import com.azure.core.http.policy.HttpPipelinePolicy;
 import lombok.AllArgsConstructor;
 import lombok.NonNull;
-import okhttp3.Interceptor;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
+import reactor.core.publisher.Mono;
 
 /**
- * Implementation of {@link ServiceClientCredentials} that provides RBAC based bearer tokens.
+ * Implementation of {@link HttpPipelinePolicy} that provides RBAC based bearer tokens.
  */
 @AllArgsConstructor
-public class ServiceClientBearerTokenCredentialProvider implements ServiceClientCredentials {
+public class ServiceClientBearerTokenCredentialProvider implements HttpPipelinePolicy {
 
     private static final String AUTHORIZATION = "Authorization";
 
@@ -22,15 +23,8 @@ public class ServiceClientBearerTokenCredentialProvider implements ServiceClient
     private final BearerTokenProvider tokenProvider;
 
     @Override
-    public void applyCredentialsFilter(OkHttpClient.Builder clientBuilder) {
-        Interceptor authenticationInterceptor = chain -> {
-            String authorizationValue = tokenProvider.getBearerToken();
-            Request authenticatedRequest = chain.request()
-                                                .newBuilder()
-                                                .header(AUTHORIZATION, authorizationValue)
-                                                .build();
-            return chain.proceed(authenticatedRequest);
-        };
-        clientBuilder.interceptors().add(authenticationInterceptor);
+    public Mono<HttpResponse> process(HttpPipelineCallContext context, HttpPipelineNextPolicy next) {
+        context.getHttpRequest().setHeader(AUTHORIZATION, tokenProvider.getBearerToken());
+        return next.process();
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/authentication/ServiceClientCredentialsProvider.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/authentication/ServiceClientCredentialsProvider.java
@@ -3,29 +3,30 @@
 
 package com.microsoft.azure.sdk.iot.service.digitaltwin.authentication;
 
-import com.microsoft.rest.credentials.ServiceClientCredentials;
+import com.azure.core.http.HttpPipelineCallContext;
+import com.azure.core.http.HttpPipelineNextPolicy;
+import com.azure.core.http.HttpResponse;
+import com.azure.core.http.policy.HttpPipelinePolicy;
 import lombok.AllArgsConstructor;
 import lombok.NonNull;
-import okhttp3.Interceptor;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
+import reactor.core.publisher.Mono;
+
+import java.io.IOException;
 
 @AllArgsConstructor
-public class ServiceClientCredentialsProvider implements ServiceClientCredentials {
+public class ServiceClientCredentialsProvider implements HttpPipelinePolicy {
 
     private static final String AUTHORIZATION = "Authorization";
     @NonNull
     private final SasTokenProvider sasTokenProvider;
 
     @Override
-    public void applyCredentialsFilter(OkHttpClient.Builder clientBuilder) {
-        Interceptor authenticationInterceptor = chain -> {
-            Request authenticatedRequest = chain.request()
-                                                .newBuilder()
-                                                .header(AUTHORIZATION, sasTokenProvider.getSasToken())
-                                                .build();
-            return chain.proceed(authenticatedRequest);
-        };
-        clientBuilder.interceptors().add(authenticationInterceptor);
+    public Mono<HttpResponse> process(HttpPipelineCallContext context, HttpPipelineNextPolicy next) {
+        try {
+            context.getHttpRequest().setHeader(AUTHORIZATION, sasTokenProvider.getSasToken());
+        } catch (IOException e) {
+            return Mono.error(e);
+        }
+        return next.process();
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/generated/DigitalTwins.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/generated/DigitalTwins.java
@@ -6,14 +6,12 @@
 
 package com.microsoft.azure.sdk.iot.service.digitaltwin.generated;
 
+import com.azure.core.exception.HttpResponseException;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.generated.models.DigitalTwinGetDigitalTwinHeaders;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.generated.models.DigitalTwinInvokeComponentCommandHeaders;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.generated.models.DigitalTwinInvokeRootLevelCommandHeaders;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.generated.models.DigitalTwinUpdateDigitalTwinHeaders;
-import com.microsoft.rest.RestException;
-import com.microsoft.rest.ServiceCallback;
-import com.microsoft.rest.ServiceFuture;
-import com.microsoft.rest.ServiceResponseWithHeaders;
+import com.microsoft.azure.sdk.iot.service.digitaltwin.models.ServiceResponseWithHeaders;
 
 import java.util.List;
 import rx.Observable;
@@ -28,21 +26,11 @@ public interface DigitalTwins {
      *
      * @param id Digital Twin ID.
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @throws RestException thrown if the request is rejected by server
+     * @throws HttpResponseException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
      * @return the Object object if successful.
      */
     Object getDigitalTwin(String id);
-
-    /**
-     * Gets a digital twin.
-     *
-     * @param id Digital Twin ID.
-     * @param serviceCallback the async ServiceCallback to handle successful and failed responses.
-     * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link ServiceFuture} object
-     */
-    ServiceFuture<Object> getDigitalTwinAsync(String id, final ServiceCallback<Object> serviceCallback);
 
     /**
      * Gets a digital twin.
@@ -68,21 +56,10 @@ public interface DigitalTwins {
      * @param id Digital Twin ID.
      * @param digitalTwinPatch json-patch contents to update.
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @throws RestException thrown if the request is rejected by server
+     * @throws HttpResponseException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
      */
     void updateDigitalTwin(String id, List<Object> digitalTwinPatch);
-
-    /**
-     * Updates a digital twin.
-     *
-     * @param id Digital Twin ID.
-     * @param digitalTwinPatch json-patch contents to update.
-     * @param serviceCallback the async ServiceCallback to handle successful and failed responses.
-     * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link ServiceFuture} object
-     */
-    ServiceFuture<Void> updateDigitalTwinAsync(String id, List<Object> digitalTwinPatch, final ServiceCallback<Void> serviceCallback);
 
     /**
      * Updates a digital twin.
@@ -103,17 +80,6 @@ public interface DigitalTwins {
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
     Observable<ServiceResponseWithHeaders<Void, DigitalTwinUpdateDigitalTwinHeaders>> updateDigitalTwinWithServiceResponseAsync(String id, List<Object> digitalTwinPatch);
-    /**
-     * Updates a digital twin.
-     *
-     * @param id Digital Twin ID.
-     * @param digitalTwinPatch json-patch contents to update.
-     * @param ifMatch the String value
-     * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @throws RestException thrown if the request is rejected by server
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
-     */
-    void updateDigitalTwin(String id, List<Object> digitalTwinPatch, String ifMatch);
 
     /**
      * Updates a digital twin.
@@ -121,11 +87,11 @@ public interface DigitalTwins {
      * @param id Digital Twin ID.
      * @param digitalTwinPatch json-patch contents to update.
      * @param ifMatch the String value
-     * @param serviceCallback the async ServiceCallback to handle successful and failed responses.
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link ServiceFuture} object
+     * @throws HttpResponseException thrown if the request is rejected by server
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
      */
-    ServiceFuture<Void> updateDigitalTwinAsync(String id, List<Object> digitalTwinPatch, String ifMatch, final ServiceCallback<Void> serviceCallback);
+    void updateDigitalTwin(String id, List<Object> digitalTwinPatch, String ifMatch);
 
     /**
      * Updates a digital twin.
@@ -155,22 +121,11 @@ public interface DigitalTwins {
      * @param id the String value
      * @param commandName the String value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @throws RestException thrown if the request is rejected by server
+     * @throws HttpResponseException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
      * @return the Object object if successful.
      */
     Object invokeRootLevelCommand(String id, String commandName);
-
-    /**
-     * Invoke a digital twin root level command.
-     *
-     * @param id the String value
-     * @param commandName the String value
-     * @param serviceCallback the async ServiceCallback to handle successful and failed responses.
-     * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link ServiceFuture} object
-     */
-    ServiceFuture<Object> invokeRootLevelCommandAsync(String id, String commandName, final ServiceCallback<Object> serviceCallback);
 
     /**
      * Invoke a digital twin root level command.
@@ -191,20 +146,6 @@ public interface DigitalTwins {
      * @return the observable to the Object object
      */
     Observable<ServiceResponseWithHeaders<Object, DigitalTwinInvokeRootLevelCommandHeaders>> invokeRootLevelCommandWithServiceResponseAsync(String id, String commandName);
-    /**
-     * Invoke a digital twin root level command.
-     *
-     * @param id the String value
-     * @param commandName the String value
-     * @param payload the Object value
-     * @param connectTimeoutInSeconds Maximum interval of time, in seconds, that the digital twin command will wait for the answer.
-     * @param responseTimeoutInSeconds Maximum interval of time, in seconds, that the digital twin command will wait for the answer.
-     * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @throws RestException thrown if the request is rejected by server
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
-     * @return the Object object if successful.
-     */
-    Object invokeRootLevelCommand(String id, String commandName, Object payload, Integer connectTimeoutInSeconds, Integer responseTimeoutInSeconds);
 
     /**
      * Invoke a digital twin root level command.
@@ -214,11 +155,12 @@ public interface DigitalTwins {
      * @param payload the Object value
      * @param connectTimeoutInSeconds Maximum interval of time, in seconds, that the digital twin command will wait for the answer.
      * @param responseTimeoutInSeconds Maximum interval of time, in seconds, that the digital twin command will wait for the answer.
-     * @param serviceCallback the async ServiceCallback to handle successful and failed responses.
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link ServiceFuture} object
+     * @throws HttpResponseException thrown if the request is rejected by server
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the Object object if successful.
      */
-    ServiceFuture<Object> invokeRootLevelCommandAsync(String id, String commandName, Object payload, Integer connectTimeoutInSeconds, Integer responseTimeoutInSeconds, final ServiceCallback<Object> serviceCallback);
+    Object invokeRootLevelCommand(String id, String commandName, Object payload, Integer connectTimeoutInSeconds, Integer responseTimeoutInSeconds);
 
     /**
      * Invoke a digital twin root level command.
@@ -253,23 +195,11 @@ public interface DigitalTwins {
      * @param componentPath the String value
      * @param commandName the String value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @throws RestException thrown if the request is rejected by server
+     * @throws HttpResponseException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
      * @return the Object object if successful.
      */
     Object invokeComponentCommand(String id, String componentPath, String commandName);
-
-    /**
-     * Invoke a digital twin command.
-     *
-     * @param id the String value
-     * @param componentPath the String value
-     * @param commandName the String value
-     * @param serviceCallback the async ServiceCallback to handle successful and failed responses.
-     * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link ServiceFuture} object
-     */
-    ServiceFuture<Object> invokeComponentCommandAsync(String id, String componentPath, String commandName, final ServiceCallback<Object> serviceCallback);
 
     /**
      * Invoke a digital twin command.
@@ -292,21 +222,6 @@ public interface DigitalTwins {
      * @return the observable to the Object object
      */
     Observable<ServiceResponseWithHeaders<Object, DigitalTwinInvokeComponentCommandHeaders>> invokeComponentCommandWithServiceResponseAsync(String id, String componentPath, String commandName);
-    /**
-     * Invoke a digital twin command.
-     *
-     * @param id the String value
-     * @param componentPath the String value
-     * @param commandName the String value
-     * @param payload the Object value
-     * @param connectTimeoutInSeconds Maximum interval of time, in seconds, that the digital twin command will wait for the answer.
-     * @param responseTimeoutInSeconds Maximum interval of time, in seconds, that the digital twin command will wait for the answer.
-     * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @throws RestException thrown if the request is rejected by server
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
-     * @return the Object object if successful.
-     */
-    Object invokeComponentCommand(String id, String componentPath, String commandName, Object payload, Integer connectTimeoutInSeconds, Integer responseTimeoutInSeconds);
 
     /**
      * Invoke a digital twin command.
@@ -317,11 +232,12 @@ public interface DigitalTwins {
      * @param payload the Object value
      * @param connectTimeoutInSeconds Maximum interval of time, in seconds, that the digital twin command will wait for the answer.
      * @param responseTimeoutInSeconds Maximum interval of time, in seconds, that the digital twin command will wait for the answer.
-     * @param serviceCallback the async ServiceCallback to handle successful and failed responses.
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link ServiceFuture} object
+     * @throws HttpResponseException thrown if the request is rejected by server
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
+     * @return the Object object if successful.
      */
-    ServiceFuture<Object> invokeComponentCommandAsync(String id, String componentPath, String commandName, Object payload, Integer connectTimeoutInSeconds, Integer responseTimeoutInSeconds, final ServiceCallback<Object> serviceCallback);
+    Object invokeComponentCommand(String id, String componentPath, String commandName, Object payload, Integer connectTimeoutInSeconds, Integer responseTimeoutInSeconds);
 
     /**
      * Invoke a digital twin command.

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/generated/IotHubGatewayServiceAPIs.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/generated/IotHubGatewayServiceAPIs.java
@@ -6,18 +6,33 @@
 
 package com.microsoft.azure.sdk.iot.service.digitaltwin.generated;
 
-import com.microsoft.rest.RestClient;
+import com.azure.core.http.HttpPipeline;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * The interface for IotHubGatewayServiceAPIs class.
  */
 public interface IotHubGatewayServiceAPIs {
     /**
-     * Gets the REST client.
+     * Gets the HTTP pipeline.
      *
-     * @return the {@link RestClient} object.
+     * @return the {@link HttpPipeline} object.
     */
-    RestClient restClient();
+    HttpPipeline httpPipeline();
+
+    /**
+     * Gets the serializer adapter (ObjectMapper).
+     *
+     * @return the ObjectMapper used for serialization.
+     */
+    ObjectMapper serializerAdapter();
+
+    /**
+     * Gets the base URL.
+     *
+     * @return the base URL.
+     */
+    String baseUrl();
 
     /**
      * The default base URL.

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/generated/implementation/DigitalTwinsImpl.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/generated/implementation/DigitalTwinsImpl.java
@@ -6,74 +6,96 @@
 
 package com.microsoft.azure.sdk.iot.service.digitaltwin.generated.implementation;
 
-import com.google.common.reflect.TypeToken;
+import com.azure.core.http.HttpMethod;
+import com.azure.core.http.HttpRequest;
+import com.azure.core.http.HttpResponse;
+import com.azure.core.exception.HttpResponseException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.generated.DigitalTwins;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.generated.models.DigitalTwinGetDigitalTwinHeaders;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.generated.models.DigitalTwinInvokeComponentCommandHeaders;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.generated.models.DigitalTwinInvokeRootLevelCommandHeaders;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.generated.models.DigitalTwinUpdateDigitalTwinHeaders;
-import com.microsoft.rest.*;
-import okhttp3.ResponseBody;
-import retrofit2.Response;
-import retrofit2.Retrofit;
-import retrofit2.http.*;
+import com.microsoft.azure.sdk.iot.service.digitaltwin.models.ServiceResponseWithHeaders;
 import rx.Observable;
 import rx.functions.Func1;
 
 import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 /**
  * An instance of this class provides access to all the operations defined
  * in DigitalTwins.
  */
-@SuppressWarnings("UnstableApiUsage")
 public class DigitalTwinsImpl implements DigitalTwins {
-    /** The Retrofit service to perform REST calls. */
-    private final DigitalTwinsService service;
     /** The service client containing this operation class. */
     private final IotHubGatewayServiceAPIsImpl client;
 
     /**
      * Initializes an instance of DigitalTwins.
      *
-     * @param retrofit the Retrofit instance built from a Retrofit Builder.
      * @param client the instance of the service client containing this operation class.
      */
-    public DigitalTwinsImpl(Retrofit retrofit, IotHubGatewayServiceAPIsImpl client) {
-        this.service = retrofit.create(DigitalTwinsService.class);
+    public DigitalTwinsImpl(IotHubGatewayServiceAPIsImpl client) {
         this.client = client;
     }
 
-    /**
-     * The interface defining all the services for DigitalTwins to be
-     * used by Retrofit to perform actually REST calls.
-     */
-    interface DigitalTwinsService {
-        @Headers({ "Content-Type: application/json; charset=utf-8", "x-ms-logging-context: com.microsoft.azure.sdk.iot.service.digitaltwin.generated.DigitalTwins getDigitalTwin" })
-        @GET("digitaltwins/{id}")
-        Observable<Response<ResponseBody>> getDigitalTwin(@Path("id") String id, @Query("api-version") String apiVersion);
-
-        @Headers({ "Content-Type: application/json; charset=utf-8", "x-ms-logging-context: com.microsoft.azure.sdk.iot.service.digitaltwin.generated.DigitalTwins updateDigitalTwin" })
-        @PATCH("digitaltwins/{id}")
-        Observable<Response<ResponseBody>> updateDigitalTwin(@Path("id") String id, @Body List<Object> digitalTwinPatch, @Header("If-Match") String ifMatch, @Query("api-version") String apiVersion);
-
-        @Headers({ "Content-Type: application/json; charset=utf-8", "x-ms-logging-context: com.microsoft.azure.sdk.iot.service.digitaltwin.generated.DigitalTwins invokeRootLevelCommand" })
-        @POST("digitaltwins/{id}/commands/{commandName}")
-        Observable<Response<ResponseBody>> invokeRootLevelCommand(@Path("id") String id, @Path("commandName") String commandName, @Body Object payload, @Query("api-version") String apiVersion, @Query("connectTimeoutInSeconds") Integer connectTimeoutInSeconds, @Query("responseTimeoutInSeconds") Integer responseTimeoutInSeconds);
-
-        @Headers({ "Content-Type: application/json; charset=utf-8", "x-ms-logging-context: com.microsoft.azure.sdk.iot.service.digitaltwin.generated.DigitalTwins invokeComponentCommand" })
-        @POST("digitaltwins/{id}/components/{componentPath}/commands/{commandName}")
-        Observable<Response<ResponseBody>> invokeComponentCommand(@Path("id") String id, @Path("componentPath") String componentPath, @Path("commandName") String commandName, @Body Object payload, @Query("api-version") String apiVersion, @Query("connectTimeoutInSeconds") Integer connectTimeoutInSeconds, @Query("responseTimeoutInSeconds") Integer responseTimeoutInSeconds);
-
+    private ObjectMapper objectMapper() {
+        return client.serializerAdapter();
     }
+
+    private String buildUrl(String path) {
+        String base = client.baseUrl();
+        if (base.endsWith("/")) {
+            base = base.substring(0, base.length() - 1);
+        }
+        return base + "/" + path;
+    }
+
+    private static void appendQueryParam(StringBuilder sb, String key, Object value) {
+        if (value == null) {
+            return;
+        }
+        sb.append(sb.indexOf("?") >= 0 ? "&" : "?");
+        sb.append(key).append("=").append(value);
+    }
+
+    /**
+     * Sends a request using the HttpPipeline and returns the response (blocking).
+     */
+    private HttpResponse sendRequest(HttpMethod method, String url, String body, String ifMatch) throws IOException {
+        HttpRequest request = new HttpRequest(method, new URL(url));
+        request.setHeader("Content-Type", "application/json; charset=utf-8");
+        if (ifMatch != null) {
+            request.setHeader("If-Match", ifMatch);
+        }
+        if (body != null) {
+            request.setBody(body.getBytes(StandardCharsets.UTF_8));
+        }
+        HttpResponse response = client.httpPipeline().send(request).block();
+        if (response == null) {
+            throw new IOException("Null response received from HttpPipeline");
+        }
+        return response;
+    }
+
+    private void throwIfError(HttpResponse response, String responseBody) {
+        int statusCode = response.getStatusCode();
+        if (statusCode < 200 || statusCode >= 300) {
+            throw new HttpResponseException("Request failed with status code " + statusCode + ": " + responseBody, response);
+        }
+    }
+
+    // ========== getDigitalTwin ==========
 
     /**
      * Gets a digital twin.
      *
      * @param id Digital Twin ID.
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @throws RestException thrown if the request is rejected by server
+     * @throws HttpResponseException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
      * @return the Object object if successful.
      */
@@ -85,22 +107,9 @@ public class DigitalTwinsImpl implements DigitalTwins {
      * Gets a digital twin.
      *
      * @param id Digital Twin ID.
-     * @param serviceCallback the async ServiceCallback to handle successful and failed responses.
-     * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link ServiceFuture} object
-     */
-    public ServiceFuture<Object> getDigitalTwinAsync(String id, final ServiceCallback<Object> serviceCallback) {
-        return ServiceFuture.fromHeaderResponse(getDigitalTwinWithServiceResponseAsync(id), serviceCallback);
-    }
-
-    /**
-     * Gets a digital twin.
-     *
-     * @param id Digital Twin ID.
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the observable to the Object object
      */
-    @SuppressWarnings({"Convert2Lambda", "Anonymous2MethodRef"})
     public Observable<Object> getDigitalTwinAsync(String id) {
         return getDigitalTwinWithServiceResponseAsync(id).map(new Func1<ServiceResponseWithHeaders<Object, DigitalTwinGetDigitalTwinHeaders>, Object>() {
             @Override
@@ -117,31 +126,33 @@ public class DigitalTwinsImpl implements DigitalTwins {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the observable to the Object object
      */
-    @SuppressWarnings("Convert2Lambda")
     public Observable<ServiceResponseWithHeaders<Object, DigitalTwinGetDigitalTwinHeaders>> getDigitalTwinWithServiceResponseAsync(String id) {
         if (id == null) {
             throw new IllegalArgumentException("Parameter id is required and cannot be null.");
         }
-        final String apiVersion = "2020-09-30";
-        return service.getDigitalTwin(id, apiVersion)
-            .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Object, DigitalTwinGetDigitalTwinHeaders>>>() {
-                @Override
-                public Observable<ServiceResponseWithHeaders<Object, DigitalTwinGetDigitalTwinHeaders>> call(Response<ResponseBody> response) {
-                    try {
-                        ServiceResponseWithHeaders<Object, DigitalTwinGetDigitalTwinHeaders> clientResponse = getDigitalTwinDelegate(response);
-                        return Observable.just(clientResponse);
-                    } catch (Throwable t) {
-                        return Observable.error(t);
-                    }
-                }
-            });
+        return Observable.defer(() -> {
+            try {
+                final String apiVersion = "2020-09-30";
+                StringBuilder urlBuilder = new StringBuilder(buildUrl("digitaltwins/" + id));
+                appendQueryParam(urlBuilder, "api-version", apiVersion);
+
+                HttpResponse response = sendRequest(HttpMethod.GET, urlBuilder.toString(), null, null);
+                String responseBody = response.getBodyAsString().block();
+                throwIfError(response, responseBody);
+
+                Object body = objectMapper().readValue(responseBody, Object.class);
+
+                DigitalTwinGetDigitalTwinHeaders headers = new DigitalTwinGetDigitalTwinHeaders();
+                headers.withETag(response.getHeaderValue("ETag"));
+
+                return Observable.just(new ServiceResponseWithHeaders<>(body, headers, response.getStatusCode()));
+            } catch (Throwable t) {
+                return Observable.error(t);
+            }
+        });
     }
 
-    private ServiceResponseWithHeaders<Object, DigitalTwinGetDigitalTwinHeaders> getDigitalTwinDelegate(Response<ResponseBody> response) throws RestException, IOException, IllegalArgumentException {
-        return this.client.restClient().responseBuilderFactory().newInstance(this.client.serializerAdapter())
-                .register(200, new TypeToken<Object>() { }.getType())
-                .buildWithHeaders(response, DigitalTwinGetDigitalTwinHeaders.class);
-    }
+    // ========== updateDigitalTwin ==========
 
     /**
      * Updates a digital twin.
@@ -149,7 +160,7 @@ public class DigitalTwinsImpl implements DigitalTwins {
      * @param id Digital Twin ID.
      * @param digitalTwinPatch json-patch contents to update.
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @throws RestException thrown if the request is rejected by server
+     * @throws HttpResponseException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
      */
     public void updateDigitalTwin(String id, List<Object> digitalTwinPatch) {
@@ -161,23 +172,9 @@ public class DigitalTwinsImpl implements DigitalTwins {
      *
      * @param id Digital Twin ID.
      * @param digitalTwinPatch json-patch contents to update.
-     * @param serviceCallback the async ServiceCallback to handle successful and failed responses.
-     * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link ServiceFuture} object
-     */
-    public ServiceFuture<Void> updateDigitalTwinAsync(String id, List<Object> digitalTwinPatch, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromHeaderResponse(updateDigitalTwinWithServiceResponseAsync(id, digitalTwinPatch), serviceCallback);
-    }
-
-    /**
-     * Updates a digital twin.
-     *
-     * @param id Digital Twin ID.
-     * @param digitalTwinPatch json-patch contents to update.
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    @SuppressWarnings({"Convert2Lambda", "Anonymous2MethodRef"})
     public Observable<Void> updateDigitalTwinAsync(String id, List<Object> digitalTwinPatch) {
         return updateDigitalTwinWithServiceResponseAsync(id, digitalTwinPatch).map(new Func1<ServiceResponseWithHeaders<Void, DigitalTwinUpdateDigitalTwinHeaders>, Void>() {
             @Override
@@ -195,28 +192,8 @@ public class DigitalTwinsImpl implements DigitalTwins {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    @SuppressWarnings("Convert2Lambda")
     public Observable<ServiceResponseWithHeaders<Void, DigitalTwinUpdateDigitalTwinHeaders>> updateDigitalTwinWithServiceResponseAsync(String id, List<Object> digitalTwinPatch) {
-        if (id == null) {
-            throw new IllegalArgumentException("Parameter id is required and cannot be null.");
-        }
-        if (digitalTwinPatch == null) {
-            throw new IllegalArgumentException("Parameter digitalTwinPatch is required and cannot be null.");
-        }
-        Validator.validate(digitalTwinPatch);
-        final String apiVersion = "2020-09-30";
-        return service.updateDigitalTwin(id, digitalTwinPatch, null, apiVersion)
-            .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, DigitalTwinUpdateDigitalTwinHeaders>>>() {
-                @Override
-                public Observable<ServiceResponseWithHeaders<Void, DigitalTwinUpdateDigitalTwinHeaders>> call(Response<ResponseBody> response) {
-                    try {
-                        ServiceResponseWithHeaders<Void, DigitalTwinUpdateDigitalTwinHeaders> clientResponse = updateDigitalTwinDelegate(response);
-                        return Observable.just(clientResponse);
-                    } catch (Throwable t) {
-                        return Observable.error(t);
-                    }
-                }
-            });
+        return updateDigitalTwinWithServiceResponseAsync(id, digitalTwinPatch, null);
     }
 
     /**
@@ -226,7 +203,7 @@ public class DigitalTwinsImpl implements DigitalTwins {
      * @param digitalTwinPatch json-patch contents to update.
      * @param ifMatch the String value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @throws RestException thrown if the request is rejected by server
+     * @throws HttpResponseException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
      */
     public void updateDigitalTwin(String id, List<Object> digitalTwinPatch, String ifMatch) {
@@ -239,24 +216,9 @@ public class DigitalTwinsImpl implements DigitalTwins {
      * @param id Digital Twin ID.
      * @param digitalTwinPatch json-patch contents to update.
      * @param ifMatch the String value
-     * @param serviceCallback the async ServiceCallback to handle successful and failed responses.
-     * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link ServiceFuture} object
-     */
-    public ServiceFuture<Void> updateDigitalTwinAsync(String id, List<Object> digitalTwinPatch, String ifMatch, final ServiceCallback<Void> serviceCallback) {
-        return ServiceFuture.fromHeaderResponse(updateDigitalTwinWithServiceResponseAsync(id, digitalTwinPatch, ifMatch), serviceCallback);
-    }
-
-    /**
-     * Updates a digital twin.
-     *
-     * @param id Digital Twin ID.
-     * @param digitalTwinPatch json-patch contents to update.
-     * @param ifMatch the String value
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    @SuppressWarnings({"Convert2Lambda", "Anonymous2MethodRef"})
     public Observable<Void> updateDigitalTwinAsync(String id, List<Object> digitalTwinPatch, String ifMatch) {
         return updateDigitalTwinWithServiceResponseAsync(id, digitalTwinPatch, ifMatch).map(new Func1<ServiceResponseWithHeaders<Void, DigitalTwinUpdateDigitalTwinHeaders>, Void>() {
             @Override
@@ -275,7 +237,6 @@ public class DigitalTwinsImpl implements DigitalTwins {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the {@link ServiceResponseWithHeaders} object if successful.
      */
-    @SuppressWarnings("Convert2Lambda")
     public Observable<ServiceResponseWithHeaders<Void, DigitalTwinUpdateDigitalTwinHeaders>> updateDigitalTwinWithServiceResponseAsync(String id, List<Object> digitalTwinPatch, String ifMatch) {
         if (id == null) {
             throw new IllegalArgumentException("Parameter id is required and cannot be null.");
@@ -283,36 +244,37 @@ public class DigitalTwinsImpl implements DigitalTwins {
         if (digitalTwinPatch == null) {
             throw new IllegalArgumentException("Parameter digitalTwinPatch is required and cannot be null.");
         }
-        Validator.validate(digitalTwinPatch);
-        final String apiVersion = "2020-09-30";
-        return service.updateDigitalTwin(id, digitalTwinPatch, ifMatch, apiVersion)
-            .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Void, DigitalTwinUpdateDigitalTwinHeaders>>>() {
-                @Override
-                public Observable<ServiceResponseWithHeaders<Void, DigitalTwinUpdateDigitalTwinHeaders>> call(Response<ResponseBody> response) {
-                    try {
-                        ServiceResponseWithHeaders<Void, DigitalTwinUpdateDigitalTwinHeaders> clientResponse = updateDigitalTwinDelegate(response);
-                        return Observable.just(clientResponse);
-                    } catch (Throwable t) {
-                        return Observable.error(t);
-                    }
-                }
-            });
+        return Observable.defer(() -> {
+            try {
+                final String apiVersion = "2020-09-30";
+                StringBuilder urlBuilder = new StringBuilder(buildUrl("digitaltwins/" + id));
+                appendQueryParam(urlBuilder, "api-version", apiVersion);
+
+                String body = objectMapper().writeValueAsString(digitalTwinPatch);
+                HttpResponse response = sendRequest(HttpMethod.PATCH, urlBuilder.toString(), body, ifMatch);
+                String responseBody = response.getBodyAsString().block();
+                throwIfError(response, responseBody);
+
+                DigitalTwinUpdateDigitalTwinHeaders headers = new DigitalTwinUpdateDigitalTwinHeaders();
+                headers.withETag(response.getHeaderValue("ETag"));
+                headers.withLocation(response.getHeaderValue("Location"));
+
+                return Observable.just(new ServiceResponseWithHeaders<Void, DigitalTwinUpdateDigitalTwinHeaders>(null, headers, response.getStatusCode()));
+            } catch (Throwable t) {
+                return Observable.error(t);
+            }
+        });
     }
 
-    private ServiceResponseWithHeaders<Void, DigitalTwinUpdateDigitalTwinHeaders> updateDigitalTwinDelegate(Response<ResponseBody> response) throws RestException, IOException, IllegalArgumentException {
-        return this.client.restClient().responseBuilderFactory().<Void, RestException>newInstance(this.client.serializerAdapter())
-                .register(202, new TypeToken<Void>() { }.getType())
-                .buildWithHeaders(response, DigitalTwinUpdateDigitalTwinHeaders.class);
-    }
+    // ========== invokeRootLevelCommand ==========
 
     /**
-     * Invoke a digital twin root level command.
      * Invoke a digital twin root level command.
      *
      * @param id the String value
      * @param commandName the String value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @throws RestException thrown if the request is rejected by server
+     * @throws HttpResponseException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
      * @return the Object object if successful.
      */
@@ -322,28 +284,12 @@ public class DigitalTwinsImpl implements DigitalTwins {
 
     /**
      * Invoke a digital twin root level command.
-     * Invoke a digital twin root level command.
-     *
-     * @param id the String value
-     * @param commandName the String value
-     * @param serviceCallback the async ServiceCallback to handle successful and failed responses.
-     * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link ServiceFuture} object
-     */
-    public ServiceFuture<Object> invokeRootLevelCommandAsync(String id, String commandName, final ServiceCallback<Object> serviceCallback) {
-        return ServiceFuture.fromHeaderResponse(invokeRootLevelCommandWithServiceResponseAsync(id, commandName), serviceCallback);
-    }
-
-    /**
-     * Invoke a digital twin root level command.
-     * Invoke a digital twin root level command.
      *
      * @param id the String value
      * @param commandName the String value
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the observable to the Object object
      */
-    @SuppressWarnings({"Convert2Lambda", "Anonymous2MethodRef"})
     public Observable<Object> invokeRootLevelCommandAsync(String id, String commandName) {
         return invokeRootLevelCommandWithServiceResponseAsync(id, commandName).map(new Func1<ServiceResponseWithHeaders<Object, DigitalTwinInvokeRootLevelCommandHeaders>, Object>() {
             @Override
@@ -355,38 +301,17 @@ public class DigitalTwinsImpl implements DigitalTwins {
 
     /**
      * Invoke a digital twin root level command.
-     * Invoke a digital twin root level command.
      *
      * @param id the String value
      * @param commandName the String value
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the observable to the Object object
      */
-    @SuppressWarnings("Convert2Lambda")
     public Observable<ServiceResponseWithHeaders<Object, DigitalTwinInvokeRootLevelCommandHeaders>> invokeRootLevelCommandWithServiceResponseAsync(String id, String commandName) {
-        if (id == null) {
-            throw new IllegalArgumentException("Parameter id is required and cannot be null.");
-        }
-        if (commandName == null) {
-            throw new IllegalArgumentException("Parameter commandName is required and cannot be null.");
-        }
-        final String apiVersion = "2020-09-30";
-        return service.invokeRootLevelCommand(id, commandName, null, apiVersion, null, null)
-            .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Object, DigitalTwinInvokeRootLevelCommandHeaders>>>() {
-                @Override
-                public Observable<ServiceResponseWithHeaders<Object, DigitalTwinInvokeRootLevelCommandHeaders>> call(Response<ResponseBody> response) {
-                    try {
-                        ServiceResponseWithHeaders<Object, DigitalTwinInvokeRootLevelCommandHeaders> clientResponse = invokeRootLevelCommandDelegate(response);
-                        return Observable.just(clientResponse);
-                    } catch (Throwable t) {
-                        return Observable.error(t);
-                    }
-                }
-            });
+        return invokeRootLevelCommandWithServiceResponseAsync(id, commandName, null, null, null);
     }
 
     /**
-     * Invoke a digital twin root level command.
      * Invoke a digital twin root level command.
      *
      * @param id the String value
@@ -395,7 +320,7 @@ public class DigitalTwinsImpl implements DigitalTwins {
      * @param connectTimeoutInSeconds Maximum interval of time, in seconds, that the digital twin command will wait for the answer.
      * @param responseTimeoutInSeconds Maximum interval of time, in seconds, that the digital twin command will wait for the answer.
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @throws RestException thrown if the request is rejected by server
+     * @throws HttpResponseException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
      * @return the Object object if successful.
      */
@@ -405,24 +330,6 @@ public class DigitalTwinsImpl implements DigitalTwins {
 
     /**
      * Invoke a digital twin root level command.
-     * Invoke a digital twin root level command.
-     *
-     * @param id the String value
-     * @param commandName the String value
-     * @param payload the Object value
-     * @param connectTimeoutInSeconds Maximum interval of time, in seconds, that the digital twin command will wait for the answer.
-     * @param responseTimeoutInSeconds Maximum interval of time, in seconds, that the digital twin command will wait for the answer.
-     * @param serviceCallback the async ServiceCallback to handle successful and failed responses.
-     * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link ServiceFuture} object
-     */
-    public ServiceFuture<Object> invokeRootLevelCommandAsync(String id, String commandName, Object payload, Integer connectTimeoutInSeconds, Integer responseTimeoutInSeconds, final ServiceCallback<Object> serviceCallback) {
-        return ServiceFuture.fromHeaderResponse(invokeRootLevelCommandWithServiceResponseAsync(id, commandName, payload, connectTimeoutInSeconds, responseTimeoutInSeconds), serviceCallback);
-    }
-
-    /**
-     * Invoke a digital twin root level command.
-     * Invoke a digital twin root level command.
      *
      * @param id the String value
      * @param commandName the String value
@@ -432,7 +339,6 @@ public class DigitalTwinsImpl implements DigitalTwins {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the observable to the Object object
      */
-    @SuppressWarnings({"Convert2Lambda", "Anonymous2MethodRef"})
     public Observable<Object> invokeRootLevelCommandAsync(String id, String commandName, Object payload, Integer connectTimeoutInSeconds, Integer responseTimeoutInSeconds) {
         return invokeRootLevelCommandWithServiceResponseAsync(id, commandName, payload, connectTimeoutInSeconds, responseTimeoutInSeconds).map(new Func1<ServiceResponseWithHeaders<Object, DigitalTwinInvokeRootLevelCommandHeaders>, Object>() {
             @Override
@@ -444,7 +350,6 @@ public class DigitalTwinsImpl implements DigitalTwins {
 
     /**
      * Invoke a digital twin root level command.
-     * Invoke a digital twin root level command.
      *
      * @param id the String value
      * @param commandName the String value
@@ -454,7 +359,6 @@ public class DigitalTwinsImpl implements DigitalTwins {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the observable to the Object object
      */
-    @SuppressWarnings("Convert2Lambda")
     public Observable<ServiceResponseWithHeaders<Object, DigitalTwinInvokeRootLevelCommandHeaders>> invokeRootLevelCommandWithServiceResponseAsync(String id, String commandName, Object payload, Integer connectTimeoutInSeconds, Integer responseTimeoutInSeconds) {
         if (id == null) {
             throw new IllegalArgumentException("Parameter id is required and cannot be null.");
@@ -462,36 +366,45 @@ public class DigitalTwinsImpl implements DigitalTwins {
         if (commandName == null) {
             throw new IllegalArgumentException("Parameter commandName is required and cannot be null.");
         }
-        final String apiVersion = "2020-09-30";
-        return service.invokeRootLevelCommand(id, commandName, payload, apiVersion, connectTimeoutInSeconds, responseTimeoutInSeconds)
-            .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Object, DigitalTwinInvokeRootLevelCommandHeaders>>>() {
-                @Override
-                public Observable<ServiceResponseWithHeaders<Object, DigitalTwinInvokeRootLevelCommandHeaders>> call(Response<ResponseBody> response) {
-                    try {
-                        ServiceResponseWithHeaders<Object, DigitalTwinInvokeRootLevelCommandHeaders> clientResponse = invokeRootLevelCommandDelegate(response);
-                        return Observable.just(clientResponse);
-                    } catch (Throwable t) {
-                        return Observable.error(t);
-                    }
+        return Observable.defer(() -> {
+            try {
+                final String apiVersion = "2020-09-30";
+                StringBuilder urlBuilder = new StringBuilder(buildUrl("digitaltwins/" + id + "/commands/" + commandName));
+                appendQueryParam(urlBuilder, "api-version", apiVersion);
+                appendQueryParam(urlBuilder, "connectTimeoutInSeconds", connectTimeoutInSeconds);
+                appendQueryParam(urlBuilder, "responseTimeoutInSeconds", responseTimeoutInSeconds);
+
+                String requestBody = payload != null ? objectMapper().writeValueAsString(payload) : null;
+                HttpResponse response = sendRequest(HttpMethod.POST, urlBuilder.toString(), requestBody, null);
+                String responseBody = response.getBodyAsString().block();
+                throwIfError(response, responseBody);
+
+                Object body = (responseBody != null && !responseBody.isEmpty()) ? objectMapper().readValue(responseBody, Object.class) : null;
+
+                DigitalTwinInvokeRootLevelCommandHeaders headers = new DigitalTwinInvokeRootLevelCommandHeaders();
+                String statusCodeHeader = response.getHeaderValue("x-ms-command-statuscode");
+                if (statusCodeHeader != null) {
+                    headers.withXMsCommandStatuscode(Integer.parseInt(statusCodeHeader));
                 }
-            });
+                headers.withXMsRequestId(response.getHeaderValue("x-ms-request-id"));
+
+                return Observable.just(new ServiceResponseWithHeaders<>(body, headers, response.getStatusCode()));
+            } catch (Throwable t) {
+                return Observable.error(t);
+            }
+        });
     }
 
-    private ServiceResponseWithHeaders<Object, DigitalTwinInvokeRootLevelCommandHeaders> invokeRootLevelCommandDelegate(Response<ResponseBody> response) throws RestException, IOException, IllegalArgumentException {
-        return this.client.restClient().responseBuilderFactory().newInstance(this.client.serializerAdapter())
-                .register(200, new TypeToken<Object>() { }.getType())
-                .buildWithHeaders(response, DigitalTwinInvokeRootLevelCommandHeaders.class);
-    }
+    // ========== invokeComponentCommand ==========
 
     /**
-     * Invoke a digital twin command.
      * Invoke a digital twin command.
      *
      * @param id the String value
      * @param componentPath the String value
      * @param commandName the String value
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @throws RestException thrown if the request is rejected by server
+     * @throws HttpResponseException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
      * @return the Object object if successful.
      */
@@ -501,22 +414,6 @@ public class DigitalTwinsImpl implements DigitalTwins {
 
     /**
      * Invoke a digital twin command.
-     * Invoke a digital twin command.
-     *
-     * @param id the String value
-     * @param componentPath the String value
-     * @param commandName the String value
-     * @param serviceCallback the async ServiceCallback to handle successful and failed responses.
-     * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link ServiceFuture} object
-     */
-    public ServiceFuture<Object> invokeComponentCommandAsync(String id, String componentPath, String commandName, final ServiceCallback<Object> serviceCallback) {
-        return ServiceFuture.fromHeaderResponse(invokeComponentCommandWithServiceResponseAsync(id, componentPath, commandName), serviceCallback);
-    }
-
-    /**
-     * Invoke a digital twin command.
-     * Invoke a digital twin command.
      *
      * @param id the String value
      * @param componentPath the String value
@@ -524,7 +421,6 @@ public class DigitalTwinsImpl implements DigitalTwins {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the observable to the Object object
      */
-    @SuppressWarnings({"Convert2Lambda", "Anonymous2MethodRef"})
     public Observable<Object> invokeComponentCommandAsync(String id, String componentPath, String commandName) {
         return invokeComponentCommandWithServiceResponseAsync(id, componentPath, commandName).map(new Func1<ServiceResponseWithHeaders<Object, DigitalTwinInvokeComponentCommandHeaders>, Object>() {
             @Override
@@ -536,7 +432,6 @@ public class DigitalTwinsImpl implements DigitalTwins {
 
     /**
      * Invoke a digital twin command.
-     * Invoke a digital twin command.
      *
      * @param id the String value
      * @param componentPath the String value
@@ -544,34 +439,11 @@ public class DigitalTwinsImpl implements DigitalTwins {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the observable to the Object object
      */
-    @SuppressWarnings("Convert2Lambda")
     public Observable<ServiceResponseWithHeaders<Object, DigitalTwinInvokeComponentCommandHeaders>> invokeComponentCommandWithServiceResponseAsync(String id, String componentPath, String commandName) {
-        if (id == null) {
-            throw new IllegalArgumentException("Parameter id is required and cannot be null.");
-        }
-        if (componentPath == null) {
-            throw new IllegalArgumentException("Parameter componentPath is required and cannot be null.");
-        }
-        if (commandName == null) {
-            throw new IllegalArgumentException("Parameter commandName is required and cannot be null.");
-        }
-        final String apiVersion = "2020-09-30";
-        return service.invokeComponentCommand(id, componentPath, commandName, null, apiVersion, null, null)
-            .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Object, DigitalTwinInvokeComponentCommandHeaders>>>() {
-                @Override
-                public Observable<ServiceResponseWithHeaders<Object, DigitalTwinInvokeComponentCommandHeaders>> call(Response<ResponseBody> response) {
-                    try {
-                        ServiceResponseWithHeaders<Object, DigitalTwinInvokeComponentCommandHeaders> clientResponse = invokeComponentCommandDelegate(response);
-                        return Observable.just(clientResponse);
-                    } catch (Throwable t) {
-                        return Observable.error(t);
-                    }
-                }
-            });
+        return invokeComponentCommandWithServiceResponseAsync(id, componentPath, commandName, null, null, null);
     }
 
     /**
-     * Invoke a digital twin command.
      * Invoke a digital twin command.
      *
      * @param id the String value
@@ -581,7 +453,7 @@ public class DigitalTwinsImpl implements DigitalTwins {
      * @param connectTimeoutInSeconds Maximum interval of time, in seconds, that the digital twin command will wait for the answer.
      * @param responseTimeoutInSeconds Maximum interval of time, in seconds, that the digital twin command will wait for the answer.
      * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @throws RestException thrown if the request is rejected by server
+     * @throws HttpResponseException thrown if the request is rejected by server
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent
      * @return the Object object if successful.
      */
@@ -591,25 +463,6 @@ public class DigitalTwinsImpl implements DigitalTwins {
 
     /**
      * Invoke a digital twin command.
-     * Invoke a digital twin command.
-     *
-     * @param id the String value
-     * @param componentPath the String value
-     * @param commandName the String value
-     * @param payload the Object value
-     * @param connectTimeoutInSeconds Maximum interval of time, in seconds, that the digital twin command will wait for the answer.
-     * @param responseTimeoutInSeconds Maximum interval of time, in seconds, that the digital twin command will wait for the answer.
-     * @param serviceCallback the async ServiceCallback to handle successful and failed responses.
-     * @throws IllegalArgumentException thrown if parameters fail the validation
-     * @return the {@link ServiceFuture} object
-     */
-    public ServiceFuture<Object> invokeComponentCommandAsync(String id, String componentPath, String commandName, Object payload, Integer connectTimeoutInSeconds, Integer responseTimeoutInSeconds, final ServiceCallback<Object> serviceCallback) {
-        return ServiceFuture.fromHeaderResponse(invokeComponentCommandWithServiceResponseAsync(id, componentPath, commandName, payload, connectTimeoutInSeconds, responseTimeoutInSeconds), serviceCallback);
-    }
-
-    /**
-     * Invoke a digital twin command.
-     * Invoke a digital twin command.
      *
      * @param id the String value
      * @param componentPath the String value
@@ -620,7 +473,6 @@ public class DigitalTwinsImpl implements DigitalTwins {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the observable to the Object object
      */
-    @SuppressWarnings({"Convert2Lambda", "Anonymous2MethodRef"})
     public Observable<Object> invokeComponentCommandAsync(String id, String componentPath, String commandName, Object payload, Integer connectTimeoutInSeconds, Integer responseTimeoutInSeconds) {
         return invokeComponentCommandWithServiceResponseAsync(id, componentPath, commandName, payload, connectTimeoutInSeconds, responseTimeoutInSeconds).map(new Func1<ServiceResponseWithHeaders<Object, DigitalTwinInvokeComponentCommandHeaders>, Object>() {
             @Override
@@ -632,7 +484,6 @@ public class DigitalTwinsImpl implements DigitalTwins {
 
     /**
      * Invoke a digital twin command.
-     * Invoke a digital twin command.
      *
      * @param id the String value
      * @param componentPath the String value
@@ -643,7 +494,6 @@ public class DigitalTwinsImpl implements DigitalTwins {
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the observable to the Object object
      */
-    @SuppressWarnings("Convert2Lambda")
     public Observable<ServiceResponseWithHeaders<Object, DigitalTwinInvokeComponentCommandHeaders>> invokeComponentCommandWithServiceResponseAsync(String id, String componentPath, String commandName, Object payload, Integer connectTimeoutInSeconds, Integer responseTimeoutInSeconds) {
         if (id == null) {
             throw new IllegalArgumentException("Parameter id is required and cannot be null.");
@@ -654,25 +504,33 @@ public class DigitalTwinsImpl implements DigitalTwins {
         if (commandName == null) {
             throw new IllegalArgumentException("Parameter commandName is required and cannot be null.");
         }
-        final String apiVersion = "2020-09-30";
-        return service.invokeComponentCommand(id, componentPath, commandName, payload, apiVersion, connectTimeoutInSeconds, responseTimeoutInSeconds)
-            .flatMap(new Func1<Response<ResponseBody>, Observable<ServiceResponseWithHeaders<Object, DigitalTwinInvokeComponentCommandHeaders>>>() {
-                @Override
-                public Observable<ServiceResponseWithHeaders<Object, DigitalTwinInvokeComponentCommandHeaders>> call(Response<ResponseBody> response) {
-                    try {
-                        ServiceResponseWithHeaders<Object, DigitalTwinInvokeComponentCommandHeaders> clientResponse = invokeComponentCommandDelegate(response);
-                        return Observable.just(clientResponse);
-                    } catch (Throwable t) {
-                        return Observable.error(t);
-                    }
-                }
-            });
-    }
+        return Observable.defer(() -> {
+            try {
+                final String apiVersion = "2020-09-30";
+                StringBuilder urlBuilder = new StringBuilder(buildUrl("digitaltwins/" + id + "/components/" + componentPath + "/commands/" + commandName));
+                appendQueryParam(urlBuilder, "api-version", apiVersion);
+                appendQueryParam(urlBuilder, "connectTimeoutInSeconds", connectTimeoutInSeconds);
+                appendQueryParam(urlBuilder, "responseTimeoutInSeconds", responseTimeoutInSeconds);
 
-    private ServiceResponseWithHeaders<Object, DigitalTwinInvokeComponentCommandHeaders> invokeComponentCommandDelegate(Response<ResponseBody> response) throws RestException, IOException, IllegalArgumentException {
-        return this.client.restClient().responseBuilderFactory().newInstance(this.client.serializerAdapter())
-                .register(200, new TypeToken<Object>() { }.getType())
-                .buildWithHeaders(response, DigitalTwinInvokeComponentCommandHeaders.class);
+                String requestBody = payload != null ? objectMapper().writeValueAsString(payload) : null;
+                HttpResponse response = sendRequest(HttpMethod.POST, urlBuilder.toString(), requestBody, null);
+                String responseBody = response.getBodyAsString().block();
+                throwIfError(response, responseBody);
+
+                Object body = (responseBody != null && !responseBody.isEmpty()) ? objectMapper().readValue(responseBody, Object.class) : null;
+
+                DigitalTwinInvokeComponentCommandHeaders headers = new DigitalTwinInvokeComponentCommandHeaders();
+                String statusCodeHeader = response.getHeaderValue("x-ms-command-statuscode");
+                if (statusCodeHeader != null) {
+                    headers.withXMsCommandStatuscode(Integer.parseInt(statusCodeHeader));
+                }
+                headers.withXMsRequestId(response.getHeaderValue("x-ms-request-id"));
+
+                return Observable.just(new ServiceResponseWithHeaders<>(body, headers, response.getStatusCode()));
+            } catch (Throwable t) {
+                return Observable.error(t);
+            }
+        });
     }
 
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/generated/implementation/IotHubGatewayServiceAPIsImpl.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/generated/implementation/IotHubGatewayServiceAPIsImpl.java
@@ -6,17 +6,19 @@
 
 package com.microsoft.azure.sdk.iot.service.digitaltwin.generated.implementation;
 
+import com.azure.core.http.HttpPipeline;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.generated.IotHubGatewayServiceAPIs;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.generated.DigitalTwins;
-import com.microsoft.rest.ServiceClient;
-import com.microsoft.rest.RestClient;
-import okhttp3.OkHttpClient;
-import retrofit2.Retrofit;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Initializes a new instance of the IotHubGatewayServiceAPIs class.
  */
-public class IotHubGatewayServiceAPIsImpl extends ServiceClient implements IotHubGatewayServiceAPIs {
+public class IotHubGatewayServiceAPIsImpl implements IotHubGatewayServiceAPIs {
+
+    private final HttpPipeline httpPipeline;
+    private final ObjectMapper objectMapper;
+    private final String baseUrl;
 
     /** Version of the Api. */
     private String apiVersion;
@@ -54,58 +56,37 @@ public class IotHubGatewayServiceAPIsImpl extends ServiceClient implements IotHu
         return this.digitalTwins;
     }
 
-    /**
-     * Initializes an instance of IotHubGatewayServiceAPIs client.
-     */
-    public IotHubGatewayServiceAPIsImpl() {
-        this("https://fully-qualified-iothubname.azure-devices.net");
+    @Override
+    public HttpPipeline httpPipeline() {
+        return this.httpPipeline;
+    }
+
+    @Override
+    public ObjectMapper serializerAdapter() {
+        return this.objectMapper;
+    }
+
+    @Override
+    public String baseUrl() {
+        return this.baseUrl;
     }
 
     /**
      * Initializes an instance of IotHubGatewayServiceAPIs client.
      *
-     * @param baseUrl the base URL of the host
+     * @param httpPipeline the HTTP pipeline for sending requests
+     * @param objectMapper the Jackson ObjectMapper for serialization
+     * @param baseUrl the base URL for the service
      */
-    private IotHubGatewayServiceAPIsImpl(String baseUrl) {
-        super(baseUrl);
-        initialize();
-    }
-
-    /**
-     * Initializes an instance of IotHubGatewayServiceAPIs client.
-     *
-     * @param clientBuilder the builder for building an OkHttp client, bundled with user configurations
-     * @param restBuilder the builder for building an Retrofit client, bundled with user configurations
-     */
-    public IotHubGatewayServiceAPIsImpl(OkHttpClient.Builder clientBuilder, Retrofit.Builder restBuilder) {
-        this("https://fully-qualified-iothubname.azure-devices.net", clientBuilder, restBuilder);
-        initialize();
-    }
-
-    /**
-     * Initializes an instance of IotHubGatewayServiceAPIs client.
-     *
-     * @param baseUrl the base URL of the host
-     * @param clientBuilder the builder for building an OkHttp client, bundled with user configurations
-     * @param restBuilder the builder for building an Retrofit client, bundled with user configurations
-     */
-    private IotHubGatewayServiceAPIsImpl(String baseUrl, OkHttpClient.Builder clientBuilder, Retrofit.Builder restBuilder) {
-        super(baseUrl, clientBuilder, restBuilder);
-        initialize();
-    }
-
-    /**
-     * Initializes an instance of IotHubGatewayServiceAPIs client.
-     *
-     * @param restClient the REST client containing pre-configured settings
-     */
-    public IotHubGatewayServiceAPIsImpl(RestClient restClient) {
-        super(restClient);
+    public IotHubGatewayServiceAPIsImpl(HttpPipeline httpPipeline, ObjectMapper objectMapper, String baseUrl) {
+        this.httpPipeline = httpPipeline;
+        this.objectMapper = objectMapper;
+        this.baseUrl = baseUrl;
         initialize();
     }
 
     private void initialize() {
         this.apiVersion = "2020-09-30";
-        this.digitalTwins = new DigitalTwinsImpl(retrofit(), this);
+        this.digitalTwins = new DigitalTwinsImpl(this);
     }
 }

--- a/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/helpers/Tools.java
+++ b/service/iot-service-client/src/main/java/com/microsoft/azure/sdk/iot/service/digitaltwin/helpers/Tools.java
@@ -15,7 +15,7 @@ import com.microsoft.azure.sdk.iot.service.digitaltwin.customized.DigitalTwinGet
 import com.microsoft.azure.sdk.iot.service.digitaltwin.models.DigitalTwinInvokeCommandHeaders;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.customized.DigitalTwinUpdateHeaders;
 import com.microsoft.azure.sdk.iot.service.exceptions.IotHubException;
-import com.microsoft.rest.ServiceResponseWithHeaders;
+import com.microsoft.azure.sdk.iot.service.digitaltwin.models.ServiceResponseWithHeaders;
 import rx.Observable;
 import rx.functions.Func1;
 
@@ -25,7 +25,7 @@ public final class Tools {
     public static final Func1<ServiceResponseWithHeaders<Object, DigitalTwinGetDigitalTwinHeaders>, Observable<ServiceResponseWithHeaders<Object, DigitalTwinGetHeaders>>> FUNC_TO_DIGITAL_TWIN_GET_RESPONSE = object -> {
         DigitalTwinGetHeaders digitalTwinGetHeaders = new DigitalTwinGetHeaders();
         digitalTwinGetHeaders.withETag(object.headers().eTag());
-        ServiceResponseWithHeaders<Object, DigitalTwinGetHeaders> result = new ServiceResponseWithHeaders<>(object.body(), digitalTwinGetHeaders, object.response());
+        ServiceResponseWithHeaders<Object, DigitalTwinGetHeaders> result = new ServiceResponseWithHeaders<>(object.body(), digitalTwinGetHeaders, object.statusCode());
         return Observable.just(result);
     };
 
@@ -33,7 +33,7 @@ public final class Tools {
         DigitalTwinUpdateHeaders digitalTwinUpdateHeaders = new DigitalTwinUpdateHeaders();
         digitalTwinUpdateHeaders.withETag(object.headers().eTag());
         digitalTwinUpdateHeaders.withLocation(object.headers().location());
-        ServiceResponseWithHeaders<Void, DigitalTwinUpdateHeaders> result = new ServiceResponseWithHeaders<>(object.body(), digitalTwinUpdateHeaders, object.response());
+        ServiceResponseWithHeaders<Void, DigitalTwinUpdateHeaders> result = new ServiceResponseWithHeaders<>(object.body(), digitalTwinUpdateHeaders, object.statusCode());
         return Observable.just(result);
     };
 
@@ -44,7 +44,7 @@ public final class Tools {
             digitalTwinCommandResponse.setStatus(object.headers().xMsCommandStatuscode());
             DigitalTwinInvokeCommandHeaders digitalTwinInvokeCommandHeaders = new DigitalTwinInvokeCommandHeaders();
             digitalTwinInvokeCommandHeaders.setRequestId(object.headers().xMsRequestId());
-            ServiceResponseWithHeaders<DigitalTwinCommandResponse, DigitalTwinInvokeCommandHeaders> result = new ServiceResponseWithHeaders<>(digitalTwinCommandResponse, digitalTwinInvokeCommandHeaders, object.response());
+            ServiceResponseWithHeaders<DigitalTwinCommandResponse, DigitalTwinInvokeCommandHeaders> result = new ServiceResponseWithHeaders<>(digitalTwinCommandResponse, digitalTwinInvokeCommandHeaders, object.statusCode());
             return Observable.just(result);
         }
         catch (JsonProcessingException e) {
@@ -60,7 +60,7 @@ public final class Tools {
             digitalTwinCommandResponse.setStatus(object.headers().xMsCommandStatuscode());
             DigitalTwinInvokeCommandHeaders digitalTwinInvokeCommandHeaders = new DigitalTwinInvokeCommandHeaders();
             digitalTwinInvokeCommandHeaders.setRequestId(object.headers().xMsRequestId());
-            ServiceResponseWithHeaders<DigitalTwinCommandResponse, DigitalTwinInvokeCommandHeaders> result = new ServiceResponseWithHeaders<>(digitalTwinCommandResponse, digitalTwinInvokeCommandHeaders, object.response());
+            ServiceResponseWithHeaders<DigitalTwinCommandResponse, DigitalTwinInvokeCommandHeaders> result = new ServiceResponseWithHeaders<>(digitalTwinCommandResponse, digitalTwinInvokeCommandHeaders, object.statusCode());
             return Observable.just(result);
         }
         catch (JsonProcessingException e) {

--- a/service/iot-service-samples/digitaltwin-service-samples/temperature-controller-service-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/TemperatureController.java
+++ b/service/iot-service-samples/digitaltwin-service-samples/temperature-controller-service-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/TemperatureController.java
@@ -12,8 +12,8 @@ import com.microsoft.azure.sdk.iot.service.digitaltwin.UpdateOperationUtility;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.customized.DigitalTwinGetHeaders;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.customized.DigitalTwinUpdateHeaders;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.models.*;
-import com.microsoft.rest.RestException;
-import com.microsoft.rest.ServiceResponseWithHeaders;
+import com.azure.core.exception.HttpResponseException;
+import com.microsoft.azure.sdk.iot.service.digitaltwin.models.ServiceResponseWithHeaders;
 
 import java.io.IOException;
 import java.time.ZoneOffset;
@@ -73,7 +73,7 @@ public class TemperatureController {
         System.out.println("Digital Twin Model Id:" + modelId);
         System.out.println("Digital Twin: " + prettyString(getResponse.body()));
         System.out.println("Digital Twin eTag: " + getResponse.headers().eTag());
-        System.out.println("Digital Twin get response message: " + getResponse.response().message());
+        System.out.println("Digital Twin get response status code: " + getResponse.statusCode());
 
         return getResponse;
     }
@@ -101,7 +101,7 @@ public class TemperatureController {
         updateOperationUtility.appendAddComponentOperation(path, properties);
         List<Object> digitalTwinUpdateOperations = updateOperationUtility.getUpdateOperations();
         ServiceResponseWithHeaders<Void, DigitalTwinUpdateHeaders> updateResponse = client.updateDigitalTwinWithResponse(digitalTwinid, digitalTwinUpdateOperations, options);
-        System.out.println("Update Digital Twin response status: " + updateResponse.response().message());
+        System.out.println("Update Digital Twin response status: " + updateResponse.statusCode());
 
         getResponse = GetDigitalTwin();
 
@@ -122,7 +122,7 @@ public class TemperatureController {
         updateOperationUtility.appendReplaceComponentOperation(path, t2properties);
         digitalTwinUpdateOperations = updateOperationUtility.getUpdateOperations();
         updateResponse = client.updateDigitalTwinWithResponse(digitalTwinid, digitalTwinUpdateOperations, options);
-        System.out.println("Update Digital Twin response status: " + updateResponse.response().message());
+        System.out.println("Update Digital Twin response status: " + updateResponse.statusCode());
 
         getResponse = GetDigitalTwin();
 
@@ -135,7 +135,7 @@ public class TemperatureController {
         updateOperationUtility.appendRemoveComponentOperation(path);
         digitalTwinUpdateOperations = updateOperationUtility.getUpdateOperations();
         updateResponse = client.updateDigitalTwinWithResponse(digitalTwinid, digitalTwinUpdateOperations, options);
-        System.out.println("Update Digital Twin response status: " + updateResponse.response().message());
+        System.out.println("Update Digital Twin response status: " + updateResponse.statusCode());
 
         GetDigitalTwin();
     }
@@ -150,9 +150,9 @@ public class TemperatureController {
             System.out.println("Command " + commandName + ", payload: " + prettyString(commandResponse.body().getPayload(String.class)));
             System.out.println("Command " + commandName + ", status: " + commandResponse.body().getStatus());
             System.out.println("Command " + commandName + ", requestId: " + commandResponse.headers().getRequestId());
-        } catch (RestException ex)
+        } catch (HttpResponseException ex)
         {
-            if(ex.response().code() == 404)
+            if(ex.getResponse().getStatusCode() == 404)
             {
                 System.out.println("Ensure the device sample is running for this sample to succeed - https://github.com/Azure/azure-iot-sdk-java/tree/main/device/iot-device-samples/pnp-device-sample/temperature-controller-device-sample.");
             }
@@ -178,9 +178,9 @@ public class TemperatureController {
             System.out.println("Command " + commandName + ", payload: " + commandResponse.body().getPayload(String.class));
             System.out.println("Command " + commandName + ", status: " + commandResponse.body().getStatus());
             System.out.println("Command " + commandName + ", requestId: " + commandResponse.headers().getRequestId());
-        } catch (RestException ex)
+        } catch (HttpResponseException ex)
         {
-            if(ex.response().code() == 404)
+            if(ex.getResponse().getStatusCode() == 404)
             {
                 System.out.println("Ensure the device sample is running for this sample to succeed - https://github.com/Azure/azure-iot-sdk-java/tree/main/device/iot-device-samples/pnp-device-sample/temperature-controller-device-sample.");
             }

--- a/service/iot-service-samples/digitaltwin-service-samples/thermostat-service-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/Thermostat.java
+++ b/service/iot-service-samples/digitaltwin-service-samples/thermostat-service-sample/src/main/java/samples/com/microsoft/azure/sdk/iot/Thermostat.java
@@ -8,7 +8,7 @@ import com.google.gson.GsonBuilder;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.DigitalTwinAsyncClient;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.UpdateOperationUtility;
 import com.microsoft.azure.sdk.iot.service.digitaltwin.serialization.BasicDigitalTwin;
-import com.microsoft.rest.RestException;
+import com.azure.core.exception.HttpResponseException;
 
 import java.io.IOException;
 import java.time.ZoneOffset;
@@ -165,8 +165,8 @@ public class Thermostat {
                         },
                         error ->
                         {
-                            RestException ex = (RestException)error;
-                            if(ex.response().code() == 404) {
+                            HttpResponseException ex = (HttpResponseException)error;
+                            if(ex.getResponse().getStatusCode() == 404) {
                                 System.out.println("Invoked Command " + commandName + " failed: " + error);
                             }
                             else {


### PR DESCRIPTION
- Replace client-runtime 1.7.14 with azure-core-http-netty 1.16.3
- Bump azure-core 1.12.0 -> 1.57.1 to align with azure-core-http-netty
- Drop guava override (was nested under client-runtime, no longer needed)
- Drop jackson-datatype-joda direct dep (only used by client-runtime)
- Add rxjava 1.3.5 to iot-service-client (transitive dependency)
- Bump iot-service-client 2.1.10 -> 2.2.0 (API change)
- Bump iot-device-client 2.4.0 -> 2.5.0
- Remove unused provisioning-* artifact-id/version properties

Refactor digitaltwin generated and hand-written code to the azure-core API surface (DigitalTwinsImpl, DigitalTwins, IotHubGatewayServiceAPIs/Impl, DigitalTwinAsyncClient, DigitalTwinClient, helpers/Tools).

Update ServiceClientCredentialsProvider to handle IOException from getSasToken(), and ServiceClientBearerTokenCredentialProvider for the new auth interface.

Update DigitalTwin samples (TemperatureController, Thermostat) and E2E tests (DigitalTwinClient*Tests, TokenCredentialTests) to the new client API.